### PR TITLE
`logger.art.bottle` requires a tag parameter

### DIFF
--- a/tasks/bottle.js
+++ b/tasks/bottle.js
@@ -70,7 +70,7 @@ function bowerBottle (increment, currentVersion) {//, isBeta) {
 		.then(() => shell('git push --tags origin HEAD'))
 		.then(getLatestTag)
 		.then(tag => {
-			logger.art.bottle();
+			logger.art.bottle(tag);
 			console.log(`${tag} tagged in git (no requirement for npm release detected)`);
 		});
 }


### PR DESCRIPTION
This was causing task to throw. /cc @wheresrhys 
