### PR TITLE
Remove the no-loop-func ESLint rule?

### DIFF
--- a/config/eslint.json
+++ b/config/eslint.json
@@ -20,7 +20,6 @@
     "new-cap": 2,
     "no-caller": 2,
     "quotes": [1, "single"],
-    "no-loop-func": 2,
     "no-irregular-whitespace": 1,
     "no-multi-spaces": 2,
     "one-var": [2, "never"],


### PR DESCRIPTION
The reasoning behind this rule is to avoid scope mistakes like this:

``` js
// every function returns `9` (maybe not intended)
for (var i = 0; i < 10; i++) {
  funcs[i] = function() {
    return i;
  };
}
```

But this doesn't really apply in ES6 because of block-scope.

Babel cleverly detects scoped variables being used inside a non-function block (adding closures where necessary) so you can rely on stuff like this working correctly:

``` js
// every function returns a different number
for (let i = 0; i < 10; i++) {
  funcs[i] = function() {
      return i;
  };
}
```

So this rule now seems unnecessarily restrictive. (Personally I think it was unnecessary even in a pre-ES6 world, as it seems weird to me to lean on a linter to tell you what scope a variable is in, but that's a different argument.) Can we remove it?
