### PR TITLE
Remove trailing slash on pipelines API call

### DIFF
--- a/lib/pipelines.js
+++ b/lib/pipelines.js
@@ -33,7 +33,7 @@ function supported(){
 function getApps(pipelineName){
 	return co(function* (){
 		let token = yield herokuAuthToken();
-		let pipelines = yield api('/pipelines/', token);
+		let pipelines = yield api('/pipelines', token);
 		let pipeline = pipelines.find(p => p.name === pipelineName);
 		if(!pipeline){
 			throw new Error('Could not find pipeline ' + pipeline);

--- a/lib/pipelines.js
+++ b/lib/pipelines.js
@@ -38,18 +38,18 @@ function getApps(pipelineName){
 		if(!pipeline){
 			throw new Error('Could not find pipeline ' + pipeline);
 		}
-
-		let apps = yield api('/pipelines/' + pipeline.id + '/apps', token);
+		let apps = yield api('/pipelines/' + pipeline.id + '/pipeline-couplings', token);
 		let result = {staging:null, production:{us:null,eu:null}, all:[]};
 		for(let app of apps){
-			result.all.push(app.name);
-			if(app.coupling.stage === 'staging'){
-				result.staging = app.name
+			result.all.push(app.app.id);
+			if(app.stage === 'staging'){
+				result.staging = app.app.id
 			}else{
-				result.production[app.region.name] = app.name
+				let region = yield api('/apps/' + app.app.id, token);
+				result.production[region.region.name] = app.app.id
 			}
 		}
-
+		// console.log(result)
 		return result;
 	});
 }

--- a/test/pipeline.test.js
+++ b/test/pipeline.test.js
@@ -44,7 +44,7 @@ describe('lib/pipelines', function (){
 		setup({mockShellPromise:false});
 		return co(function* (){
 			let apps = yield pipelines.getApps('ft-next-health');
-			expect(apps.production.eu).to.equal('ft-next-health-eu');
+			expect(apps.production.eu).to.equal('112136c5-59cb-4806-aa6b-9a439450140f');
 		});
 	});
 


### PR DESCRIPTION
The slash appears to HTTP 503 (from 30 April, 2016) 

/cc @matthew-andrews
