### PR TITLE
Add ability to monitor assets when deploying

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "isomorphic-fetch": "^2.0.0",
     "md5-file": "^3.1.0",
     "mime": "^1.3.4",
+    "next-metrics": "^1.30.4",
     "semver": "^5.0.3",
     "shellpromise": "^1.0.0"
   },

--- a/tasks/deploy-hashed-assets.js
+++ b/tasks/deploy-hashed-assets.js
@@ -75,6 +75,8 @@ function task (opts) {
 
 				return readFile(path.join(process.cwd(), 'public', file))
 					.then(content => {
+						// ignore source maps
+						const isMonitoringAsset = shouldMonitorAssets && path.extname(file) !== '.map';
 						let params = {
 							Key: key,
 							Body: content,
@@ -93,11 +95,10 @@ function task (opts) {
 							.then(() => Promise.all([
 								waitForOk(`http://${bucket}.s3-website-${region}.amazonaws.com/${key}`),
 								waitForOk(`http://${usBucket}.s3-website-${usRegion}.amazonaws.com/${key}`),
-								shouldMonitorAssets ? gzip(content) : Promise.resolve()
+								isMonitoringAsset ? gzip(content) : Promise.resolve()
 							]))
 							.then(values => {
-								// ignore source maps
-								if (!shouldMonitorAssets || path.extname(file) === '.map') {
+								if (!isMonitoringAsset) {
 									return;
 								}
 								const contentSize = Buffer.byteLength(content);

--- a/tasks/deploy-hashed-assets.js
+++ b/tasks/deploy-hashed-assets.js
@@ -60,7 +60,7 @@ function task (opts) {
 		app: app,
 		instance: false,
 		useDefaultAggregators: false,
-		flushEvery: 60000
+		flushEvery: false
 	});
 
 	console.log('Deploying hashed assets to S3...');


### PR DESCRIPTION
With `--monitor-assets`, sends asset size/gzip size to Graphite

Dependent on https://github.com/Financial-Times/next-metrics/pull/116