### PR TITLE
Fix broken nodemon args

### DIFF
--- a/tasks/run.js
+++ b/tasks/run.js
@@ -59,7 +59,7 @@ function runLocal(opts) {
 		}
 
 		if(opts.nodemon) {
-			args.push('--watch server');
+			args.push('--watch', 'server');
 
 			return ['nodemon', args, { cwd: process.cwd(), env: env }];
 		} else {


### PR DESCRIPTION
When doing `make run` in next-front-page, I was getting errors like this:

```
[nodemon] Internal watch failed: watch /Users/callum/code/ft/next/front-page/node_modules/moment/locale/pt-br.js ENFILE
```

...ie. the nodemon watcher was trying to open too many files at once, too many for my OS. (It errored with a different file path every time, but always something inside node_modules, implying it's trying to watch for changes in there.)

I think the problem was the nodemon CLI args are wrongly set up in n-heroku-tools. When spawning a child process, you have to treat something like `--watch server` as two separate CLI arguments, otherwise the space gets escaped so this comes in as a single argument, `--watch\ server`, which nodemon would ignore. So nodemon has been defaulting to watching the whole CWD including `node_modules` and `bower_components`.

After making this change locally I no longer hit ENFILE errors.