### PR TITLE
Don't watch anything with nodemon

### DIFF
--- a/tasks/run.js
+++ b/tasks/run.js
@@ -59,8 +59,6 @@ function runLocal(opts) {
 		}
 
 		if(opts.nodemon) {
-			args.push('--watch', 'server');
-
 			return ['nodemon', args, { cwd: process.cwd(), env: env }];
 		} else {
 			return ['node', args, { cwd: process.cwd(), env: env }];


### PR DESCRIPTION
Problem is, if you set `watch` on the command line, you can't set `watch` in the `nodemon.json` as well

I propose removing it from here, and letting each app have its own `nodemon.json` file where it can define what dirs to watch, e.g. https://github.com/Financial-Times/next-front-page/blob/master/nodemon.json

Related to https://github.com/Financial-Times/n-heroku-tools/pull/395

@callumlocke, not sure if you'll get memory issues though. If so, could potentially remove `node_modules`, though it is useful when working on a module that's been `link`ed