### PR TITLE
Add sessionId to globals object

### DIFF
--- a/config/nightwatch-globals.js
+++ b/config/nightwatch-globals.js
@@ -23,6 +23,7 @@ module.exports = {
 	afterEach: function (browser, done) {
 		const sessionId = browser.sessionId;
 		const results = browser.currentTest.results;
+		this.sessionId = sessionId;
 		console.log(`Sauce Test Results at https://saucelabs.com/tests/${browser.sessionId}`);
 		if (results.failed || results.errors) {
 			browser


### PR DESCRIPTION
This helps to make the sessionId available on test reports (needed for https://github.com/Financial-Times/n-automation)
cc @ironsidevsquincy