### PR TITLE
Ensure .env file is loaded for smoke tests

### DIFF
--- a/lib/smoke-test.js
+++ b/lib/smoke-test.js
@@ -200,6 +200,7 @@ function testUrls (opts) {
 }
 
 function runTest (opts) {
+	require('dotenv').load();
 	const appName = (opts.app) ? opts.app : 'ft-next-' + normalizeName(packageJson.name);
 	const urlConfig = require(path.join(process.cwd(), opts.configPath || 'test/smoke.js'));
 	baseUrl = appName;


### PR DESCRIPTION
@wheresrhys 

Naive (but possible acceptable?) approach to ensuring the .env file is loaded for smoke tests, so that we can use env for to pass authentication for routes we want to test