### PR TITLE
Add Nightwatch clickWithJs command

### DIFF
--- a/config/nightwatch-commands/clickWithJs.js
+++ b/config/nightwatch-commands/clickWithJs.js
@@ -1,7 +1,5 @@
 exports.command = function (selector, callback) {
-	this.execute(function (s) {
+	return this.execute(function (s) {
 		document.querySelector(s).click();
 	}, [selector], callback);
-
-	return this;
 };

--- a/config/nightwatch-commands/clickWithJs.js
+++ b/config/nightwatch-commands/clickWithJs.js
@@ -1,0 +1,7 @@
+exports.command = function (selector, callback) {
+	this.execute(function (s) {
+		document.querySelector(s).click();
+	}, [selector], callback);
+
+	return this;
+};

--- a/config/nightwatch.json
+++ b/config/nightwatch.json
@@ -2,6 +2,7 @@
   "src_folders": ["test/browser/tests"],
   "output_folder": "./test/browser/reports",
   "globals_path": "./node_modules/@financial-times/n-heroku-tools/config/nightwatch-globals.js",
+  "custom_commands_path": "./node_modules/@financial-times/n-heroku-tools/config/nightwatch-commands",
   "test_workers": true,
   "test_settings": {
     "default": {


### PR DESCRIPTION
Using the standard `click` can fail if the element being clicked on is visually underneath another element (v. possible these days with all our floating overlays)