### PR TITLE
Ability to use function for expected content for smoke tests

### DIFF
--- a/lib/smoke-test.js
+++ b/lib/smoke-test.js
@@ -120,8 +120,13 @@ See https://github.com/Financial-Times/n-heroku-tools/blob/master/docs/smoke.md 
 					return response
 						.text()
 						.then(text => {
-							if (text !== this.expected.content) {
-								throw 'bad content: ' + text;
+							var errorMessage = 'bad content: ' + text;
+							if (typeof this.expected.content === 'function') {
+								if (!this.expected.content(text)) {
+									throw errorMessage;
+								}
+							} else if (text !== this.expected.content) {
+								throw errorMessage;
 							}
 						});
 				}


### PR DESCRIPTION
Function is passed the response text, and fails the test if returns false

cc: @wheresrhys 