### PR TITLE
Allow all certs if smoke testing locally over https

### DIFF
--- a/lib/smoke-test.js
+++ b/lib/smoke-test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const https = require('https');
 const normalizeName = require('../lib/normalize-name');
 const directly = require('directly');
 const packageJson = require(process.cwd() + '/package.json');
@@ -72,20 +73,27 @@ See https://github.com/Financial-Times/n-heroku-tools/blob/master/docs/smoke.md 
 	}
 
 	checkUrl () {
-		fetch(this.url, {
+		const fetchOptions = {
 			timeout: this.timeout || 5000,
 			headers: this.headers,
 			method: this.method,
 			body: this.body,
 			redirect: 'manual'
-		})
+		};
+		// if testing locally over HTTPS, accept all certs, e.g. the self-signed one we use locally
+		const parsedUrl = url.parse(this.url);
+		if (parsedUrl.protocol === 'https:' && ['local.ft.com', 'localhost'].indexOf(parsedUrl.hostname) > -1) {
+			fetchOptions.agent = new https.Agent({
+				rejectUnauthorized: false
+			});
+		}
+		fetch(this.url, fetchOptions)
 			.then(response => {
 				cacheHeaders[this.url] = {
 					'Cache-Control': response.headers.get('Cache-Control') || '',
 					'Surrogate-Control': response.headers.get('Surrogate-Control') || '',
 					'FT-Outbound-Cache-Control': response.headers.get('FT-Outbound-Cache-Control') || ''
 				}
-
 
 				if (this.expected.redirect) {
 					const location = response.headers.get('location');


### PR DESCRIPTION
As the cert we use to run the app locally over SSL is self-signed