### PR TITLE
No utf-8 encoding for images

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "fetchres": "^1.0.4",
     "foreman": "^1.4.1",
     "haikro": "^2.2.0",
+    "is-image": "^1.0.1",
     "isomorphic-fetch": "^2.0.0",
     "md5-file": "^3.1.0",
     "mime": "^1.3.4",

--- a/tasks/deploy-static.js
+++ b/tasks/deploy-static.js
@@ -11,6 +11,7 @@ const co = require('co');
 const md5File = denodeify(require('md5-file'));
 const gzip = denodeify(require('zlib').gzip);
 const Metrics = require('next-metrics').Metrics;
+const isImage = require('is-image');
 
 function task (opts) {
 	opts.region = opts.region || 'eu-west-1';
@@ -50,9 +51,7 @@ function task (opts) {
 
 	return Promise.all(files.map(function (file) {
 		return co(function*() {
-			const imgFileExt = /\.(png|jpg|gif)$/i;
-			const isImage = imgFileExt.test(file);
-			const content = (isImage) ? yield readFile(file) : yield readFile(file, { encoding: 'utf-8' });
+			const content = (isImage(file)) ? yield readFile(file) : yield readFile(file, { encoding: 'utf-8' });
 			file = path.relative(process.cwd(), file);
 			let key = file;
 			const isMonitoringAsset = opts.monitor && path.extname(file) !== '.map';

--- a/tasks/deploy-static.js
+++ b/tasks/deploy-static.js
@@ -50,7 +50,9 @@ function task (opts) {
 
 	return Promise.all(files.map(function (file) {
 		return co(function*() {
-			const content = yield readFile(file, { encoding: 'utf-8' });
+			const imgFileExt = /\.(png|jpg|gif)$/i;
+			const isImage = imgFileExt.test(file);
+			const content = (isImage) ? yield readFile(file) : yield readFile(file, { encoding: 'utf-8' });
 			file = path.relative(process.cwd(), file);
 			let key = file;
 			const isMonitoringAsset = opts.monitor && path.extname(file) !== '.map';


### PR DESCRIPTION
Images had started to become corrupted after upload to s3 when handled with deploy-static. Let the s3 uploader handle encoding for anything ending with .png, .gif, or .jpg