### PR TITLE
Smoke test names

### DIFF
--- a/docs/smoke.md
+++ b/docs/smoke.md
@@ -34,6 +34,7 @@ For each set of urls additional options can be set to configure the requests
 - `headers`: an object of key/value pairs defining headers to send
 - `method`: http method to use (defaults to GET)
 - `body`: object (which will be converted to JSON) or string to send as body
+- `name`: a name for this set of URLs which will be output in test results
 
 All urls expecting a status code of `200` will be automatically added to the list of URLs to test for accessibility issues in user-facing apps (example [.pa11yci.js](https://github.com/Financial-Times/next-article/blob/master/.pa11yci.js) file. Per-app exceptions allowed)
 
@@ -47,6 +48,7 @@ module.exports = [
 		}
 	},
 	{
+		name: 'can create user',
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',

--- a/lib/smoke-test.js
+++ b/lib/smoke-test.js
@@ -42,6 +42,7 @@ Any old app can serve a /__gtg, but it takes a smooth running one to serve a rea
 See https://github.com/Financial-Times/n-heroku-tools/blob/master/docs/smoke.md for docs.`)
 		}
 		this.url = opts.url;
+		this.name = opts.name ? `(${opts.name}) ` : '';
 		this.timeout = opts.timeout;
 		this.headers = opts.headers || {};
 		if (authenticate) {
@@ -140,7 +141,7 @@ See https://github.com/Financial-Times/n-heroku-tools/blob/master/docs/smoke.md 
 				}
 			})
 			.then(() => {
-				this.end(null, this.url + ' responded as expected');
+				this.end(null, `${this.name}${this.url} responded as expected`);
 			})
 			.catch(err => {
 				if (err.message) {
@@ -155,7 +156,7 @@ See https://github.com/Financial-Times/n-heroku-tools/blob/master/docs/smoke.md 
 					this.failures.push(err);
 				}
 
-				this.end(this.url + ': ' + err, null);
+				this.end(`${this.name}${this.url}: ${err}`, null);
 			});
 	}
 

--- a/lib/smoke-test.js
+++ b/lib/smoke-test.js
@@ -165,6 +165,7 @@ See https://github.com/Financial-Times/n-heroku-tools/blob/master/docs/smoke.md 
 function testUrls (opts) {
 	const fetchers = Object.keys(opts.urls).map(function (url) {
 		const test = new UrlTest({
+			name: opts.name,
 			url: (opts.https ? 'https' : 'http') + '://' + baseUrl + url,
 			headers: opts.headers,
 			expectation: opts.urls[url],


### PR DESCRIPTION
This allows each smoke test  to be annotated with a 'name' property, so we can distinguish test failures when the same URL is used for more than one test.