### PR TITLE
n-ui reminder for Developers

### DIFF
--- a/tasks/run.js
+++ b/tasks/run.js
@@ -6,6 +6,7 @@ var packageJson = require(process.cwd() + '/package.json');
 var normalizeName = require('../lib/normalize-name');
 var keys = require('../lib/keys');
 var path = require('path');
+const shell = require('shellpromise');
 
 function toStdOut(data) {
 	process.stdout.write(data.toString());
@@ -137,8 +138,27 @@ function ensureRouterInstall() {
 		.catch(function () { throw new Error('You need to install the next router first!  See docs here: https://github.com/Financial-Times/next-router'); });
 }
 
+// Remind developers that if they want to use a local version of n-ui,
+// they need to `export NEXT_APP_SHELL=local`.
+function devNui() {
+	if (
+		(!process.env.NODE_ENV || process.env.NODE_ENV !== 'production') // Not production
+		&& !process.env.CIRCLE_BRANCH // Not CircleCI
+		&& (!process.env.NEXT_APP_SHELL || process.env.NEXT_APP_SHELL !== 'local')  // NEXT_APP_SHELL is not set to local
+	) {
+		// Check if the app is using n-ui
+		shell('grep -s -Fim 1 n-ui bower.json')
+			.then(res => {
+				if (res !== '') toStdOut('Developers: If you want your app to point to n-ui locally, then `export NEXT_APP_SHELL=local`. \r\n')
+			})
+			.catch(() => null);
+	}
+}
+
 function task (opts) {
 	var localPort = process.env.PORT || 3002;
+
+	devNui();
 
 	if (opts.local) {
 		return runLocal({ PORT: localPort, harmony: opts.harmony, debug: opts.debug, script: opts.script, nodemon: opts.nodemon, https: opts.https, inspect: opts.inspect });


### PR DESCRIPTION
@wheresrhys 

Related to https://github.com/Financial-Times/n-makefile/pull/141/files

Remind developers that if they want to use a local version of n-ui, they need to 'export NEXT_APP_SHELL=local'

![image](https://cloud.githubusercontent.com/assets/224547/22478172/cb8717da-e7e0-11e6-9e1b-e4852f35df47.png)
