### PR TITLE
Check routes

### DIFF
--- a/lib/smoke-test.js
+++ b/lib/smoke-test.js
@@ -35,6 +35,8 @@ function getExpectation (expected) {
 
 class UrlTest {
 	constructor (opts) {
+
+
 		if (opts.url === '/__gtg') {
 			throw new Error(`A smoke test for /__gtg is cheating!! Do not pass GO!
 Smoke tests MUST be for a genuine url served by the app.
@@ -163,6 +165,7 @@ See https://github.com/Financial-Times/n-heroku-tools/blob/master/docs/smoke.md 
 }
 
 function testUrls (opts) {
+
 	const fetchers = Object.keys(opts.urls).map(function (url) {
 		const test = new UrlTest({
 			name: opts.name,
@@ -180,8 +183,9 @@ function testUrls (opts) {
 }
 
 function verifyUserFacingApp (appName, services, urlConfig) {
+
 	const service = services.find(service => {
-		return service.nodes.some(node => appName.indexOf(node.url.replace(/-(eu|us)$/)) === 0)
+		return service.nodes.some(node => node.url.replace(/-(eu|us)$/).indexOf(appName) !== -1)
 	})
 
 	// it's a user-facing service, so we'll be very strict

--- a/lib/smoke-test.js
+++ b/lib/smoke-test.js
@@ -35,8 +35,6 @@ function getExpectation (expected) {
 
 class UrlTest {
 	constructor (opts) {
-
-
 		if (opts.url === '/__gtg') {
 			throw new Error(`A smoke test for /__gtg is cheating!! Do not pass GO!
 Smoke tests MUST be for a genuine url served by the app.
@@ -165,7 +163,6 @@ See https://github.com/Financial-Times/n-heroku-tools/blob/master/docs/smoke.md 
 }
 
 function testUrls (opts) {
-
 	const fetchers = Object.keys(opts.urls).map(function (url) {
 		const test = new UrlTest({
 			name: opts.name,
@@ -183,7 +180,6 @@ function testUrls (opts) {
 }
 
 function verifyUserFacingApp (appName, services, urlConfig) {
-
 	const service = services.find(service => {
 		return service.nodes.some(node => node.url.replace(/-(eu|us)$/).indexOf(appName) !== -1)
 	})

--- a/lib/smoke-test.js
+++ b/lib/smoke-test.js
@@ -196,7 +196,7 @@ function verifyUserFacingApp (appName, services, urlConfig) {
 		service.paths.forEach(path => {
 			const rx = new RegExp(path.replace('$',''));
 			if (!urls.some(url => rx.test(url))) {
-				console.log(chalk.bgYellow.black(`No smoke tests found in smoke.js to cover the path ${path} served by this app. This will soon break your builds.`))
+				console.log(chalk.bgYellow.black(`No smoke tests defined in smoke.js to cover the path ${path} served by this app. This will soon break your builds.`))
 			}
 		})
 

--- a/lib/smoke-test.js
+++ b/lib/smoke-test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const chalk = require('chalk');
 const https = require('https');
 const normalizeName = require('../lib/normalize-name');
 const directly = require('directly');
@@ -191,10 +192,11 @@ function verifyUserFacingApp (appName, services, urlConfig) {
 		const urls = urlConfig.reduce((arr, conf) => {
 			return arr.concat(Object.keys(conf.urls));
 		}, [])
+
 		service.paths.forEach(path => {
-			const rx = new RegExp(path);
+			const rx = new RegExp(path.replace('$',''));
 			if (!urls.some(url => rx.test(url))) {
-				throw new Error(`No smoke tests defined to cover the path ${path} served by this app`);
+				console.log(chalk.bgYellow.black(`No smoke tests found in smoke.js to cover the path ${path} served by this app. This will soon break your builds.`))
 			}
 		})
 

--- a/lib/smoke-test.js
+++ b/lib/smoke-test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const path = require('path');
-const chalk = require('chalk');
 const https = require('https');
 const normalizeName = require('../lib/normalize-name');
 const directly = require('directly');
@@ -195,7 +194,7 @@ function verifyUserFacingApp (appName, services, urlConfig) {
 		service.paths.forEach(path => {
 			const rx = new RegExp(path.replace('$',''));
 			if (!urls.some(url => rx.test(url))) {
-				console.log(chalk.bgYellow.black(`No smoke tests defined in smoke.js to cover the path ${path} served by this app. This will soon break your builds.`))
+				logger.warn(`No smoke tests defined in smoke.js to cover the path ${path} served by this app. This will soon break your builds.`);
 			}
 		})
 

--- a/lib/smoke-test.js
+++ b/lib/smoke-test.js
@@ -192,7 +192,6 @@ function verifyUserFacingApp (appName, services, urlConfig) {
 		const urls = urlConfig.reduce((arr, conf) => {
 			return arr.concat(Object.keys(conf.urls));
 		}, [])
-
 		service.paths.forEach(path => {
 			const rx = new RegExp(path.replace('$',''));
 			if (!urls.some(url => rx.test(url))) {


### PR DESCRIPTION
@wheresrhys this check is brilliant (checking smoke.js includes all of that app's routes if it's user-facing) but the conditional was being skipped:

now it checks that:

`http://ft-next-signup-eu.herokuapp.com` contains `ft-next-signup`, rather than the other way around

Also, I have a feeling this will blow up all the things. Which isn't terrible. We need this.