### PR TITLE
Normalize Vault names

### DIFF
--- a/tasks/configure.js
+++ b/tasks/configure.js
@@ -26,9 +26,16 @@ function fetchFromNextConfigVars(source, target, key) {
 
 function fetchFromVault(source, target) {
 	console.log(`Fetching ${source} config from the vault for ${target}`);
-	const pathPrefix = 'secret/teams/next';
-	return vault.get()
-		.then(vault => vault.read(`${pathPrefix}/${source}/production`))
+
+	const normalizedSource = normalizeName(source);
+
+	const path = fetch('https://next-registry.ft.com/v2/')
+		.then(fetchres)
+		.then(json => json.find(app => app.name === normalizedSource).config)
+		.then(url => url.substring(0, url.indexOf('https://vault.in.ft.com/v1/')))
+
+	return Promise.all([path, vault.get()])
+		.then(([path, vault]) => vault.read(`${path}/production`))
 		.then(response => response.data);
 }
 

--- a/tasks/configure.js
+++ b/tasks/configure.js
@@ -27,11 +27,9 @@ function fetchFromNextConfigVars(source, target, key) {
 function fetchFromVault(source, target) {
 	console.log(`Fetching ${source} config from the vault for ${target}`);
 
-	const normalizedSource = normalizeName(source);
-
 	const path = fetch('https://next-registry.ft.com/v2/')
 		.then(fetchres)
-		.then(json => json.find(app => app.name === normalizedSource).config)
+		.then(json => json.find(app => app.name === normalizeName(source)).config)
 		.then(url => url.substring(0, url.indexOf('https://vault.in.ft.com/v1/')))
 
 	return Promise.all([path, vault.get()])


### PR DESCRIPTION
There's going to be a mix of app names, `spoor-foobar`, `ft-next-foobar`, `foobar`, `next-foobar`

Normalize the name, then get the path from the registry.