### PR TITLE
add router type option

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "scripts": {
     "precommit": "node_modules/.bin/secret-squirrel",
-    "prepush": "make verify -j3"
+    "prepush": "make verify -j3",
+    "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg"
   }
 }

--- a/tasks/run.js
+++ b/tasks/run.js
@@ -129,14 +129,14 @@ function runRouter(opts) {
 		});
 
 	return configureAndSpawn(envVars, function (env) {
-		var bin = opts.https ? 'next-router-https' : 'next-router';
+		var bin = opts.https ? `${opts.router}-https` : `${opts.router}`;
 		return [bin, { env: env }];
 	});
 }
 
-function ensureRouterInstall() {
-	return exec('which next-router')
-		.catch(function () { throw new Error('You need to install the next router first!  See docs here: https://github.com/Financial-Times/next-router'); });
+function ensureRouterInstall(router) {
+	return exec(`which ${router}`)
+		.catch(function () { throw new Error(`You need to install the ${router} first!  See docs here: https://github.com/Financial-Times/${router}`); });
 }
 
 // Remind developers that if they want to use a local version of n-ui,
@@ -162,18 +162,18 @@ function task (opts) {
 	devNui();
 
 	if (opts.local) {
-		return runLocal({ PORT: localPort, harmony: opts.harmony, debug: opts.debug, script: opts.script, nodemon: opts.nodemon, https: opts.https, inspect: opts.inspect });
+		return runLocal({ PORT: localPort, harmony: opts.harmony, debug: opts.debug, script: opts.script, nodemon: opts.nodemon, https: opts.https, inspect: opts.inspect, router: opts.router });
 	} else if (opts.procfile) {
 		return runProcfile();
 	} else if (opts.script) {
-		return runScript({script: opts.script, harmony: opts.harmony, debug: opts.debug, subargs: opts.subargs});
+		return runScript({ script: opts.script, harmony: opts.harmony, debug: opts.debug, subargs: opts.subargs, router: opts.router });
 	} else {
 		const localApps = opts.localApps ? extractLocalApps(opts.localApps) : [];
-		return ensureRouterInstall()
+		return ensureRouterInstall(opts.router)
 			.then(function () {
 				return Promise.all([
-					runLocal({ PORT: localPort, harmony: opts.harmony, debug: opts.debug, nodemon: opts.nodemon, inspect: opts.inspect }),
-					runRouter({ PORT: opts.port, localPort: localPort, harmony: opts.harmony, https: opts.https, cert: opts.cert, key: opts.key, localApps: localApps })
+					runLocal({ PORT: localPort, harmony: opts.harmony, debug: opts.debug, nodemon: opts.nodemon, inspect: opts.inspect, router: opts.router }),
+					runRouter({ PORT: opts.port, localPort: localPort, harmony: opts.harmony, https: opts.https, cert: opts.cert, key: opts.key, localApps: localApps, router: opts.router })
 				]);
 			});
 	}
@@ -196,6 +196,7 @@ module.exports = function (program, utils) {
 		.option('--key <file>', 'Specify a certificate key to use with HTTPS. Use with --https.')
 		.option('--local-apps <apps>', 'Specify extra apps that are running locally, as comma-seperated `[name]=[port]`, e.g. `service-worker=3001,front-page=3002`')
 		.option('-p --port <port>', 'Port to run the router through', 5050)
+		.option('--router <router>', 'Router to run using', 'next-router')
 		.action(function (opts){
 			task(opts).catch(utils.exit);
 		});

--- a/tasks/run.js
+++ b/tasks/run.js
@@ -129,7 +129,7 @@ function runRouter(opts) {
 		});
 
 	return configureAndSpawn(envVars, function (env) {
-		var bin = opts.https ? `${opts.router}-https` : `${opts.router}`;
+		var bin = opts.https ? `${opts.router}-https` : opts.router;
 		return [bin, { env: env }];
 	});
 }


### PR DESCRIPTION
 🐿 v2.5.16

This adds an option to specify which local router to use. use case for this is to be able to use `kat-router` like `next-router`, nice and easily.

Related: https://github.com/Financial-Times/kat-router/pull/3