### PR TITLE
normalise app name in ship command

### DIFF
--- a/tasks/ship.js
+++ b/tasks/ship.js
@@ -7,6 +7,7 @@ const packageJson = require(process.cwd() + '/package.json');
 const pipelines = require('../lib/pipelines');
 const deploy = require('./deploy').task;
 const log = require('../lib/logger');
+const normalizeName = require('../lib/normalize-name');
 
 const DEFAULT_REGISTRY_URI = 'https://next-registry.ft.com/v2/';
 
@@ -14,7 +15,7 @@ function task (opts) {
 
 	return co(function* (){
 
-		let appName = packageJson.name.replace('ft-next-', '');
+		let appName = normalizeName(packageJson.name);
 		let pipelineName = opts.pipeline || packageJson.name;
 		log.info('Deploy to ' + pipelineName);
 		let apps = yield pipelines.getApps(pipelineName);

--- a/test/ship.alternateRegistry.test.js
+++ b/test/ship.alternateRegistry.test.js
@@ -96,7 +96,7 @@ describe('tasks/ship (using alternate registry)', function (){
 			});
 
 			sinon.assert.calledWith(mockScale.task, {
-				source:appName,
+				source: 'kat-app',
 				target:mockApps.staging,
 				minimal:true,
 				registry: OVERRIDE_REGISTRY_URI
@@ -140,17 +140,17 @@ describe('tasks/ship (using alternate registry)', function (){
 			});
 
 			sinon.assert.calledWith(mockScale.task, {
-				source:appName,
+				source:'kat-app',
 				target:mockApps.staging,
 				registry: OVERRIDE_REGISTRY_URI
 			});
 			sinon.assert.calledWith(mockScale.task, {
-				source:appName,
+				source:'kat-app',
 				target:mockApps.production.eu,
 				registry: OVERRIDE_REGISTRY_URI
 			});
 			sinon.assert.calledWith(mockScale.task, {
-				source:appName,
+				source:'kat-app',
 				target:mockApps.production.us,
 				registry: OVERRIDE_REGISTRY_URI
 			});
@@ -169,7 +169,7 @@ describe('tasks/ship (using alternate registry)', function (){
 			});
 
 			sinon.assert.calledWith(mockScale.task, {
-				source:appName,
+				source:'kat-app',
 				target:mockApps.staging,
 				inhibit:true,
 				registry: OVERRIDE_REGISTRY_URI


### PR DESCRIPTION
If an app name (in it's package.json) wasn't prefixed with `ft-next` it meant it wasn't getting stripped out, this meant that the `kat-api` wasn't being scaled up properly 

 🐿 v2.5.16