### PR TITLE
Update foreman to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "directly": "^1.0.1",
     "dotenv": "^1.2.0",
     "fetchres": "^1.0.4",
-    "foreman": "^1.4.1",
+    "foreman": "^1.15.3",
     "haikro": "^2.2.0",
     "is-image": "^1.0.1",
     "isomorphic-fetch": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "directly": "^1.0.1",
     "dotenv": "^1.2.0",
     "fetchres": "^1.0.4",
-    "foreman": "^1.15.3",
+    "foreman": "^2.0.0",
     "haikro": "^2.2.0",
     "is-image": "^1.0.1",
     "isomorphic-fetch": "^2.0.0",


### PR DESCRIPTION
`foreman@1.4.1` depends on `shell-quote@1.4.3` which contains a known vulnerability.