### PR TITLE
Fix for issue with hyphenated environment variables

### DIFF
--- a/tasks/run.js
+++ b/tasks/run.js
@@ -128,7 +128,7 @@ function runRouter (opts) {
 	(opts.localApps || [])
 		.concat({ name: normalizeName(packageJson.name, { version: false }), port: opts.localPort })
 		.forEach(function (localApp) {
-			const localAppEnvVar = localApp.name.toUpperCase().replace(/\-/, '_');
+			const localAppEnvVar = localApp.name.toUpperCase().replace(/\-/g, '_');
 			envVars[localAppEnvVar] = localApp.port;
 			envVars[localApp.name] = localApp.port;
 		});

--- a/tasks/run.js
+++ b/tasks/run.js
@@ -128,12 +128,14 @@ function runRouter (opts) {
 	(opts.localApps || [])
 		.concat({ name: normalizeName(packageJson.name, { version: false }), port: opts.localPort })
 		.forEach(function (localApp) {
+			const localAppEnvVar = localApp.name.toUpperCase().replace(/\-/, '_');
+			envVars[localAppEnvVar] = localApp.port;
 			envVars[localApp.name] = localApp.port;
 		});
 
 	return configureAndSpawn(envVars, function (env) {
 		let bin = opts.https ? `${opts.router}-https` : opts.router;
-		return [bin, { env: env }];
+		return [bin, { env }];
 	});
 }
 


### PR DESCRIPTION
Make `n-heroku-tools` set `UPPERCASE_SNAKECASE` style names for those env vars that hold the port number of apps that need to be run locally.

This is a fix for https://github.com/Financial-Times/n-heroku-tools/issues/489, where the rationale is also explained.

The old `lowercase-spinalcase` style env vars are still being set for backward compatibility.

Related PR: https://github.com/Financial-Times/next-router/pull/128.