### PR TITLE
Pass build params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ devs.json
 npm-debug.log
 .eslintrc.js
 .editorconfig
+*.env*
+.vscode

--- a/tasks/rebuild.js
+++ b/tasks/rebuild.js
@@ -37,7 +37,8 @@ const rebuildMasterBuild = (project, body) => circleFetch(`/project/Financial-Ti
 const lastMasterBuild = (project) => circleFetch(`/project/Financial-Times/${project}/tree/master`);
 
 const getRepoName = (app) => {
-	const repoUrl = Object.values(app.versions).find(version => version.repo).repo;
+	const version = Object.values(app.versions).find(version => version.repo)
+	const repoUrl = version && version.repo;
 	if (/https?:\/\/github\.com\/Financial-Times\//.test(repoUrl)) {
 		return repoUrl
 			.replace(/https?:\/\/github\.com\/Financial-Times\//, '')
@@ -45,7 +46,7 @@ const getRepoName = (app) => {
 	}
 };
 
-const hasVersions = (app) => app.versions['1'] || app.versions['2'];
+const hasVersions = (app) => app.versions && (app.versions['1'] || app.versions['2']);
 
 const serves = type => app => type ? app.serves && app.serves.includes(type) : true;
 


### PR DESCRIPTION
Adds ability to pass build parameters to the triggered builds. The reason I'm wanting to add this is so that we can report on user-facing apps that fail on an n-ui tagged release.

With this change, an n-ui tagged release would now run:
```sh
nht rebuild --all --serves user-page --params NUI_RELEASE_BUILD=true
```

Then `next-webhooks` can filter and failed builds with the `NUI_RELEASE_BUILD` build_parameter and notifiy the person that released n-ui so that they can rebuild.

I'm wary this may be contentious so, thoughts?