### PR TITLE
Move URL resolving for smoke tests into here

### DIFF
--- a/lib/host.js
+++ b/lib/host.js
@@ -12,5 +12,18 @@ module.exports = {
 		return process.env.CIRCLE_BRANCH === 'master' ||
 				process.env.GIT_BRANCH === 'master' ||
 			(!process.env.TRAVIS_PULL_REQUEST && process.env.TRAVIS_BRANCH === 'master');
+	},
+
+	url: (appName) => {
+		let host = appName || 'http://local.ft.com:3002';
+		if (!/:|\./.test(host)) {
+			host += '.herokuapp.com';
+		}
+
+		if (!/https?\:\/\//.test(host)) {
+			host = 'http://' + host;
+		}
+
+		return host;
 	}
 };

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -4,6 +4,7 @@ const packageJson = require(process.cwd() + '/package.json');
 const herokuAuthToken = require('../lib/heroku-auth-token');
 const deploy = require('haikro/lib/deploy');
 const normalizeName = require('../lib/normalize-name');
+const host = require('../lib/host');
 const waitForOk = require('../lib/wait-for-ok');
 const denodeify = require('denodeify');
 const fs = require('fs');
@@ -54,7 +55,7 @@ See https://github.com/Financial-Times/n-heroku-tools/blob/master/docs/smoke.md 
 If this app has no web process use the --skip-gtg option`);
 						}
 						return waitForOk(`http://${name}.herokuapp.com/__gtg`)
-							.then(() => smokeTest.run({host: name, auth: opts.authenticatedSmokeTests}))
+							.then(() => smokeTest.run({host: host.url(name), auth: opts.authenticatedSmokeTests}))
 							.catch(err => {
 								console.log('/**************** heroku app logs start ****************/'); // eslint-disable-line no-console
 								return shell('heroku logs -a ' + name, { verbose: true })

--- a/tasks/smoke.js
+++ b/tasks/smoke.js
@@ -1,3 +1,4 @@
+const host = require('../lib/host');
 const nTest = require('@financial-times/n-test');
 const task = opts => nTest.smoke.run(opts);
 
@@ -8,7 +9,7 @@ module.exports = function (program) {
 		.description('[DEPRECATED - Use n-test directly]. Tests that a given set of urls for an app respond as expected. Expects the config file ./test/smoke.js to exist')
 		.action(function (app, opts) {
 			task({
-				host: app,
+				host: host.url(app),
 				authenticate: opts.auth
 			});
 		});


### PR DESCRIPTION
 🐿 v2.7.0

In an attempt to make the smoke testing more generic/open-sourceable, move the bit where we resolve the heroku URL into here (where it makes more sense, being n-heroku-tools 😬 )