### PR TITLE
Do not watch node-modules

### DIFF
--- a/tasks/run.js
+++ b/tasks/run.js
@@ -79,6 +79,7 @@ function runLocal (opts) {
 
 		if(opts.nodemon) {
 			args.push('--ignore', 'public/');
+			args.push('--ignore', 'node-modules/');
 			return ['nodemon', args, { cwd: process.cwd(), env: env }];
 		} else {
 			return ['node', args, { cwd: process.cwd(), env: env }];


### PR DESCRIPTION
 🐿 v2.8.0

- change: do not watch the node-modules folder
- fix for https://github.com/Financial-Times/n-heroku-tools/issues/500

(note: 2nd day at the FT, please let me know if I'm doing anything wrong!)