### PR TITLE
Update Heroku error to make it clearer when build fails

### DIFF
--- a/tasks/destroy.js
+++ b/tasks/destroy.js
@@ -5,18 +5,22 @@ let spawn = require('shellpromise');
 function task (options) {
 	let app = options.app;
 	let verbose = options.verbose;
-	let promise = Promise.resolve();
-	if (verbose) {
-		promise = promise.then(function () {
 
+	return spawn('heroku info ' + app, {verbose: true }).then(function () {
+		let promise = Promise.resolve();
+		if (verbose) {
+			promise = promise.then(function () {
 				// `|| echo` to stop this failing failing builds
 				return spawn('heroku logs -a ' + app + ' || echo', { verbose: true });
 			});
-	}
-	promise = promise.then(function () {
+		}
+		promise = promise.then(function () {
 			return spawn('heroku destroy -a ' + app + ' --confirm ' + app, { verbose: true });
 		});
-	return promise;
+		return promise;
+	}).catch(function () {
+		console.log(app + ' does not exist'); // eslint-disable-line no-console
+	});
 };
 
 module.exports = function (program, utils) {

--- a/tasks/destroy.js
+++ b/tasks/destroy.js
@@ -6,7 +6,7 @@ function task (options) {
 	let app = options.app;
 	let verbose = options.verbose;
 
-	return spawn('heroku info ' + app, {verbose: true }).then(function () {
+	return spawn('heroku info ' + app).then(function () {
 		let promise = Promise.resolve();
 		if (verbose) {
 			promise = promise.then(function () {


### PR DESCRIPTION
 🐿 v2.8.0

![image](https://user-images.githubusercontent.com/30316203/38624077-20abc4f8-3d9f-11e8-964a-3fff2aa480e3.png)

When a test fails, the build proceeds to `make tidy` and tries to clean up a Heroku app that doesn't exist. The resulting error is quite confusing (see image above) so this hopefully makes it a bit more clear!