### PR TITLE
Show resonse code from heroku when setting config

### DIFF
--- a/tasks/configure.js
+++ b/tasks/configure.js
@@ -153,7 +153,10 @@ function task (opts) {
 						body: JSON.stringify(patch)
 					});
 				})
-				.then(function () {
+				.then(function (response) {
+					if( !response.ok ) {
+						console.warn('Heroku responded with ' + response.status); // eslint-disable-line no-console
+					}
 					console.log(target + ' config vars are set'); // eslint-disable-line no-console
 				}));
 			});


### PR DESCRIPTION
This is to assist debugging a problem where config isn't being set. Perhaps the response to fetch isn't 200, so this change will show what it is.

 🐿 v2.10.2