### PR TITLE
Add gtg as a standalone task

### DIFF
--- a/bin/n-heroku-tools.js
+++ b/bin/n-heroku-tools.js
@@ -36,6 +36,7 @@ require('../tasks/ship')(program, utils);
 require('../tasks/float')(program, utils);
 require('../tasks/drydock')(program, utils);
 require('../tasks/smoke')(program, utils);
+require('../tasks/gtg')(program, utils);
 
 program
 	.command('*')

--- a/tasks/gtg.js
+++ b/tasks/gtg.js
@@ -1,0 +1,12 @@
+const host = require('../lib/host');
+const waitForOk = require('../lib/wait-for-ok');
+
+module.exports = function (program) {
+	program
+		.command('gtg [app]')
+		.description('Runs gtg checks for an app')
+		.action(function (app) {
+			const url = `${host.url(app)}/__gtg`;
+			return waitForOk(url);
+		});
+};


### PR DESCRIPTION
Currently nht does gtg checks as part of tasks like `float` and `ship`.

This PR allows running a gtg check as a standalone task from the command line. This feature is needed for customizing the `provision` and `deploy` processes in CircleCI mainly for non-javascript apps like `next-ammit-anubis`.

**Example:** Running `nht gtg ft-next-ammit-anubis` will give this result:
```
⏳ polling: http://ft-next-ammit-anubis.herokuapp.com/__gtg
✅ http://ft-next-ammit-anubis.herokuapp.com/__gtg ok!
```

🐿 v2.7.0