### PR TITLE
Remove asset size metrics from deploy-hashed-assets / deploy-static

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "isomorphic-fetch": "^2.0.0",
     "md5-file": "^3.1.0",
     "mime": "^1.3.4",
-    "next-metrics": "^1.48.18",
     "node-vault": "^0.5.6",
     "nodemon": "^1.11.0",
     "semver": "^5.0.3",

--- a/tasks/deploy-hashed-assets.js
+++ b/tasks/deploy-hashed-assets.js
@@ -7,7 +7,6 @@ const readFile = denodeify(require('fs').readFile);
 const waitForOk = require('../lib/wait-for-ok');
 const path = require('path');
 const aws = require('aws-sdk');
-const Metrics = require('next-metrics').Metrics;
 
 const AWS_ACCESS_HASHED_ASSETS = process.env.AWS_ACCESS_HASHED_ASSETS || process.env.aws_access_hashed_assets;
 const AWS_SECRET_HASHED_ASSETS = process.env.AWS_SECRET_HASHED_ASSETS || process.env.aws_secret_hashed_assets;
@@ -58,16 +57,6 @@ function task (opts) {
 	}
 
 	const app = normalizeName(packageJson.name, { version: false });
-
-	const metrics = new Metrics;
-	metrics.init({
-		platform: 's3',
-		app: app,
-		instance: false,
-		useDefaultAggregators: false,
-		flushEvery: false,
-		forceGraphiteLogging: true
-	});
 
 	console.log('Deploying hashed assets to S3...'); // eslint-disable-line no-console
 
@@ -121,15 +110,10 @@ function task (opts) {
 								const contentSize = Buffer.byteLength(content);
 								const gzippedContentSize = Buffer.byteLength(values[2]);
 								console.log(`${file} is ${contentSize} bytes (${gzippedContentSize} bytes gzipped)`); // eslint-disable-line no-console
-								metrics.count(`${file}.size`, contentSize);
-								metrics.count(`${file}.gzip_size`, gzippedContentSize);
 							});
 					});
 			})
-		)
-		.then(() => {
-			metrics.flush();
-		});
+		);
 }
 
 module.exports = function (program, utils) {


### PR DESCRIPTION
This is tricky to do now that FT Graphite v2 requires every client that is sending metrics to have an app UUID. Given that `nht` is a CLI tool that has been sending metrics from CI environments, this starts to get a bit messy.

We've decided to drop the sending of metrics from `nht` as there is ongoing work to improve how we deploy and how we build the UI for applications. Hopefully those efforts will be able to reintroduce asset size metrics in some other form.