### PR TITLE
Stop scaling the production apps when shipping

### DIFF
--- a/tasks/ship.js
+++ b/tasks/ship.js
@@ -86,33 +86,6 @@ function task (opts) {
 		log.info('Promote slug to production');
 		yield pipelines.promote(apps.staging);
 		log.success('Slug promoted');
-		if(opts.scale){
-			log.log('scale enabled');
-			let source = appName;
-			let scaleTasks = [
-				scale({
-					source:source,
-					target:apps.staging,
-					registry: REGISTRY_URI
-				}),
-				scale({
-					source:source,
-					target:apps.production.eu,
-					registry: REGISTRY_URI
-				})
-			];
-			if(opts.multiregion){
-				scaleTasks.push(scale({
-					source:source,
-					target:apps.production.us,
-					registry: REGISTRY_URI
-				}));
-			}
-
-			log.info('scale production apps');
-			yield Promise.all(scaleTasks);
-			log.success('scale complete');
-		}
 
 		log.info('scale staging app back to 0');
 		yield scale({
@@ -132,9 +105,8 @@ function task (opts) {
 module.exports = function (program, utils) {
 	program
 		.command('ship')
-		.description('Ships code.  Deploys using pipelines, also running the configure and scale steps automatically')
+		.description('Ships code.  Deploys using pipelines, also running the configure step automatically')
 		.option('-c --no-configure', 'Skip the configure step')
-		.option('-s --no-scale', 'Skip the scale step')
 		.option('-p --pipeline [name]', 'The name of the pipeline to deploy to.  Defaults to the app name')
 		.option('-r, --registry [registry-uri]', `use this registry, instead of the default: ${DEFAULT_REGISTRY_URI}`, DEFAULT_REGISTRY_URI)
 		.option('-m --multiregion', 'Will expect a US app as well as an EU one')

--- a/test/ship.alternateRegistry.test.js
+++ b/test/ship.alternateRegistry.test.js
@@ -140,17 +140,6 @@ describe('tasks/ship (using alternate registry)', function (){
 				registry: OVERRIDE_REGISTRY_URI,
 				minimal: true
 			});
-			sinon.assert.neverCalledWith(mockScale.task, {
-				source:'kat-app',
-				target:mockApps.production.eu,
-				registry: OVERRIDE_REGISTRY_URI
-			});
-			sinon.assert.neverCalledWith(mockScale.task, {
-				source:'kat-app',
-				target:mockApps.production.us,
-				registry: OVERRIDE_REGISTRY_URI
-			});
-
 		});
 	});
 

--- a/test/ship.alternateRegistry.test.js
+++ b/test/ship.alternateRegistry.test.js
@@ -124,12 +124,12 @@ describe('tasks/ship (using alternate registry)', function (){
 		});
 	});
 
-	it('Should be able to run the scale task on the production apps', function (){
+	it('Should not run the scale task on the production apps', function (){
 		let pipelineName = 'test';
 		return co(function* (){
 			yield ship({
 				pipeline:pipelineName,
-				scale:true,
+				scale:true, //this option has been removed
 				multiregion:true,
 				registry: OVERRIDE_REGISTRY_URI
 			});
@@ -137,14 +137,15 @@ describe('tasks/ship (using alternate registry)', function (){
 			sinon.assert.calledWith(mockScale.task, {
 				source:'kat-app',
 				target:mockApps.staging,
-				registry: OVERRIDE_REGISTRY_URI
+				registry: OVERRIDE_REGISTRY_URI,
+				minimal: true
 			});
-			sinon.assert.calledWith(mockScale.task, {
+			sinon.assert.neverCalledWith(mockScale.task, {
 				source:'kat-app',
 				target:mockApps.production.eu,
 				registry: OVERRIDE_REGISTRY_URI
 			});
-			sinon.assert.calledWith(mockScale.task, {
+			sinon.assert.neverCalledWith(mockScale.task, {
 				source:'kat-app',
 				target:mockApps.production.us,
 				registry: OVERRIDE_REGISTRY_URI

--- a/test/ship.test.js
+++ b/test/ship.test.js
@@ -123,17 +123,6 @@ describe('tasks/ship', function (){
 				target:mockApps.staging,
 				registry: DEFAULT_REGISTRY_URI
 			});
-			sinon.assert.neverCalledWith(mockScale.task, {
-				source:appName,
-				target:mockApps.production.eu,
-				registry: DEFAULT_REGISTRY_URI
-			});
-			sinon.assert.neverCalledWith(mockScale.task, {
-				source:appName,
-				target:mockApps.production.us,
-				registry: DEFAULT_REGISTRY_URI
-			});
-
 		});
 	});
 

--- a/test/ship.test.js
+++ b/test/ship.test.js
@@ -111,23 +111,24 @@ describe('tasks/ship', function (){
 		});
 	});
 
-	it('Should be able to run the scale task on the production apps', function (){
+	it('Should not scale the production apps', function (){
 		let pipelineName = 'test';
 		let appName = 'sample-app';
 		return co(function* (){
 			yield ship({pipeline:pipelineName,scale:true,multiregion:true});
 
 			sinon.assert.calledWith(mockScale.task, {
+				minimal: true,
 				source:appName,
 				target:mockApps.staging,
 				registry: DEFAULT_REGISTRY_URI
 			});
-			sinon.assert.calledWith(mockScale.task, {
+			sinon.assert.neverCalledWith(mockScale.task, {
 				source:appName,
 				target:mockApps.production.eu,
 				registry: DEFAULT_REGISTRY_URI
 			});
-			sinon.assert.calledWith(mockScale.task, {
+			sinon.assert.neverCalledWith(mockScale.task, {
 				source:appName,
 				target:mockApps.production.us,
 				registry: DEFAULT_REGISTRY_URI


### PR DESCRIPTION
 🐿 v2.7.0

## What
Stop trying to scale production apps when deploying.

## Why

Heroku have changed something in their stack, so that when preboot is enabled (as it is and needs to be on all of our apps), trying to scale just after deploying will throw an error. This only happens if the current production formation is different to the specified formation in the service registry.

This leads to confusing behaviour in CI, where the deploy step will go red - even though the app has been deployed.

This resolves https://github.com/Financial-Times/next/issues/150

We have also discussed in https://github.com/Financial-Times/next/issues/182 whether keeping scaling information in code is even necessary. (tl;dr - no)

## Next Steps
- [ ] Remove all the formation information from next-service-registry