### PR TITLE
Enable review apps to be configured on the pipeline rather than the app

### DIFF
--- a/lib/heroku-api.js
+++ b/lib/heroku-api.js
@@ -1,13 +1,20 @@
-function herokuApi ({ endpoint, authToken }) {
+const merge = require('lodash.merge');
+
+function herokuApi ({ endpoint, authToken, options = {} }) {
+
+	const defaultFetchOptions = {
+		headers: {
+			Accept: 'application/vnd.heroku+json; version=3',
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${authToken}`
+		}
+	};
+
+	const fetchOptions = merge(defaultFetchOptions, options);
+
 	return fetch(
 		`https://api.heroku.com${endpoint}`,
-		{
-			headers: {
-				Accept: 'Accept: application/vnd.heroku+json; version=3',
-				'Content-Type': 'application/json',
-				Authorization: `Bearer ${authToken}`
-			}
-		}
+		fetchOptions
 	).then(response => {
 		const { ok, status, statusText } = response;
 		if (!ok) {

--- a/lib/heroku-auth-token.js
+++ b/lib/heroku-auth-token.js
@@ -1,21 +1,35 @@
 'use strict';
 
 let shellpromise = require('shellpromise');
+let authToken;
 
-module.exports = function () {
+const getAuthFromCli = () => {
+	return shellpromise('heroku auth:whoami 2>/dev/null')
+		.then(function () {
+			return shellpromise('heroku auth:token 2>/dev/null');
+		})
+		.then(function (token) {
+			return token.trim();
+		})
+		.catch(function (err) {
+			console.error(err); // eslint-disable-line no-console
+			throw new Error('Please make sure the Heroku CLI is authenticated by running `heroku auth:token`');
+		});
+};
+
+module.exports = async function () {
 	if (process.env.HEROKU_AUTH_TOKEN) {
+
 		return Promise.resolve(process.env.HEROKU_AUTH_TOKEN);
+
 	} else {
-		return shellpromise('heroku auth:whoami 2>/dev/null')
-			.then(function () {
-				return shellpromise('heroku auth:token 2>/dev/null');
-			})
-			.then(function (token) {
-				return token.trim();
-			})
-			.catch(function (err) {
-				console.error(err); // eslint-disable-line no-console
-				throw new Error('Please make sure the Heroku CLI is authenticated by running `heroku auth:token`');
-			});
+
+		if (authToken) {
+			return authToken;
+		} else {
+			authToken = await getAuthFromCli();
+			return authToken;
+		}
+
 	}
 };

--- a/lib/heroku-config-vars.js
+++ b/lib/heroku-config-vars.js
@@ -9,7 +9,7 @@ class HerokuConfigVars {
 
 		this.headers = {};
 		this.endpoint = null;
-	
+
 		if (target === 'review-app') {
 			this.headers.Accept = 'application/vnd.heroku+json; version=3.pipelines';
 			this.endpoint = `/pipelines/${pipelineId}/stage/review/config-vars`;
@@ -33,7 +33,7 @@ class HerokuConfigVars {
 	async makeApiCall (options = {}) {
 
 		let herokuApiResponse;
-	
+
 		try {
 			herokuApiResponse = await herokuApi({
 				endpoint: this.endpoint,
@@ -50,7 +50,7 @@ class HerokuConfigVars {
 				throw err;
 			}
 		}
-	
+
 		return herokuApiResponse;
 	}
 

--- a/lib/heroku-config-vars.js
+++ b/lib/heroku-config-vars.js
@@ -1,0 +1,59 @@
+const herokuApi = require('./heroku-api');
+
+class HerokuConfigVars {
+
+	constructor (settings) {
+		const { target, pipelineId, authToken } = settings;
+
+		this.authToken = authToken;
+
+		this.headers = {};
+		this.endpoint = null;
+	
+		if (target === 'review-app') {
+			this.headers.Accept = 'application/vnd.heroku+json; version=3.pipelines';
+			this.endpoint = `/pipelines/${pipelineId}/stage/review/config-vars`;
+		} else {
+			this.headers.Accept = 'application/vnd.heroku+json; version=3';
+			this.endpoint = `/apps/${target}/config-vars`;
+		}
+	}
+
+	get () {
+		return this.makeApiCall();
+	}
+
+	set (patch) {
+		return this.makeApiCall({
+			method: 'patch',
+			body: JSON.stringify(patch)
+		});
+	}
+
+	async makeApiCall (options = {}) {
+
+		let herokuApiResponse;
+	
+		try {
+			herokuApiResponse = await herokuApi({
+				endpoint: this.endpoint,
+				authToken: this.authToken,
+				options: {
+					headers: this.headers,
+					...options
+				}
+			});
+		} catch(err) {
+			if (err.name === 'BAD_RESPONSE' && err.status === 404) {
+				throw new Error('The specified app does not seem to exist in Heroku');
+			} else {
+				throw err;
+			}
+		}
+	
+		return herokuApiResponse;
+	}
+
+}
+
+module.exports = HerokuConfigVars;

--- a/lib/heroku-config-vars.js
+++ b/lib/heroku-config-vars.js
@@ -14,7 +14,6 @@ class HerokuConfigVars {
 			this.headers.Accept = 'application/vnd.heroku+json; version=3.pipelines';
 			this.endpoint = `/pipelines/${pipelineId}/stage/review/config-vars`;
 		} else {
-			this.headers.Accept = 'application/vnd.heroku+json; version=3';
 			this.endpoint = `/apps/${target}/config-vars`;
 		}
 	}

--- a/lib/heroku-config-vars.js
+++ b/lib/heroku-config-vars.js
@@ -1,14 +1,33 @@
+/**
+* Retrieves and sets config vars by calling the Heroku API.
+*/
 const herokuApi = require('./heroku-api');
 
 class HerokuConfigVars {
 
 	constructor (settings) {
+		/**
+		* @param target - The target app to be configured.
+		* @param pipelineId - Unique identifier of the Heroku pipeline.
+		* @param authToken - Heroku authentication token.
+		*/
 		const { target, pipelineId, authToken } = settings;
 
 		this.authToken = authToken;
 
 		this.headers = {};
 		this.endpoint = null;
+
+		/**
+		* Review apps are configured on the pipeline since we don't want to have to wait
+		* for the app to be created. This is done with a prototype API, which uses a
+		* different URL and Accept header.
+		*
+		* This prototype API currently supports the test environment only, so staging
+		* and prod apps are directly configured using the standard API.
+		*
+		* Prototype API docs: https://devcenter.heroku.com/articles/review-apps-beta#pipeline-config-vars
+		*/
 
 		if (target === 'review-app') {
 			this.headers.Accept = 'application/vnd.heroku+json; version=3.pipelines';
@@ -18,10 +37,16 @@ class HerokuConfigVars {
 		}
 	}
 
+	/**
+	* Gets the config vars from Heroku.
+	*/
 	get () {
 		return this.makeApiCall();
 	}
 
+	/**
+	* Sets the config vars in Heroku.
+	*/
 	set (patch) {
 		return this.makeApiCall({
 			method: 'patch',
@@ -29,6 +54,11 @@ class HerokuConfigVars {
 		});
 	}
 
+	/**
+	* Calls the Heroku API with the correct endpoint, authentication token and headers.
+	* It accepts options, which are merged into one object with the headers.
+	* @return object - The api response containing config vars.
+	*/
 	async makeApiCall (options = {}) {
 
 		let herokuApiResponse;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "foreman": "^3.0.0",
     "is-image": "^1.0.1",
     "isomorphic-fetch": "^2.0.0",
+    "lodash.merge": "^4.6.1",
     "md5-file": "^3.1.0",
     "mime": "^1.3.4",
     "node-vault": "^0.5.6",

--- a/tasks/configure.js
+++ b/tasks/configure.js
@@ -14,9 +14,7 @@ const FORBIDDEN_ATTACHMENT_VARIABLES = [
 
 const DEFAULT_REGISTRY_URI = 'https://next-registry.ft.com/v2/';
 
-const getServiceData = (source, registry) => {
-
-	return fetch(registry)
+const getServiceData = (source, registry) => fetch(registry)
 		.then(response => response.json())
 		.then(json => {
 			const serviceData = findService(json, normalizeName(source));
@@ -28,9 +26,8 @@ const getServiceData = (source, registry) => {
 				return serviceData;
 			}
 		});
-};
 
-function fetchFromVault (serviceData) {
+const fetchFromVault = (serviceData) => {
 	const path = serviceData.config.replace('https://vault.in.ft.com/v1/', '');
 
 	return Promise.all([path, vault.get()])
@@ -72,7 +69,7 @@ function fetchFromVault (serviceData) {
 					throw e;
 				});
 		});
-}
+};
 
 const fetchSessionToken = (userType, url, apiKey) => {
 	return fetch(`${url}/${userType}?api_key=${apiKey}`)
@@ -153,7 +150,7 @@ async function task (opts) {
 		if (patch[key] === null) {
 			console.log(`Deleting config var: ${key}`); // eslint-disable-line no-console
 		} else if (patch[key] !== current[key]) {
-			console.log(`Setting config var: ${key}`); // eslint-disable-line no-console
+			console.log(`Adding new config var: ${key}`); // eslint-disable-line no-console
 		}
 	});
 

--- a/tasks/configure.js
+++ b/tasks/configure.js
@@ -31,7 +31,7 @@ const getServiceData = (source, registry) => {
 };
 
 function fetchFromVault (serviceData) {
-	const path = serviceData.config.replace('https://vault.in.ft.com/v1/','');
+	const path = serviceData.config.replace('https://vault.in.ft.com/v1/', '');
 
 	return Promise.all([path, vault.get()])
 		.then(([path, vault]) => {
@@ -123,7 +123,7 @@ async function task (opts) {
 	console.log(`Retrieving current and desired config vars...`); // eslint-disable-line no-console
 
 	const [ desired, current ] = await Promise.all([
-		fetchFromVault(source, target, serviceData),
+		fetchFromVault(serviceData),
 		herokuConfigVars.get()
 	]);
 

--- a/tasks/configure.js
+++ b/tasks/configure.js
@@ -105,11 +105,8 @@ async function task (opts) {
 
 	console.log('Retrieving pipeline details from Heroku...'); // eslint-disable-line no-console
 
-	// TODO: Investigate what herokuAuthToken is doing
-	const [ authToken, pipelineId ] = await Promise.all([
-		herokuAuthToken(),
-		getPipelineId(source)
-	]);
+	const authToken = await herokuAuthToken();
+	const pipelineId = await getPipelineId(source);
 
 	const herokuConfigVars = new HerokuConfigVars({ target, pipelineId, authToken });
 

--- a/tasks/configure.js
+++ b/tasks/configure.js
@@ -147,7 +147,7 @@ async function task (opts) {
 		if (patch[key] === null) {
 			console.log(`Deleting config var: ${key}`); // eslint-disable-line no-console
 		} else if (patch[key] !== current[key]) {
-			console.log(`Adding new config var: ${key}`); // eslint-disable-line no-console
+			console.log(`Adding or updating config var: ${key}`); // eslint-disable-line no-console
 		}
 	});
 

--- a/tasks/configure.js
+++ b/tasks/configure.js
@@ -89,11 +89,9 @@ const fetchSessionToken = (userType, url, apiKey) => {
 		});
 };
 
-const getPipelineId = (pipelineName) => {
-	return pipelines.info(pipelineName)
-		.then(pipeline => {
-			return pipeline.id;
-		});
+const getPipelineId = async (pipelineName) => {
+	const pipeline = await pipelines.info(pipelineName);
+	return pipeline.id;
 };
 
 async function task (opts) {
@@ -108,7 +106,7 @@ async function task (opts) {
 		});
 	}
 
-	console.log(`Retrieving pipeline details from Heroku...`); // eslint-disable-line no-console
+	console.log('Retrieving pipeline details from Heroku...'); // eslint-disable-line no-console
 
 	// TODO: Investigate what herokuAuthToken is doing
 	const [ authToken, pipelineId ] = await Promise.all([
@@ -120,7 +118,7 @@ async function task (opts) {
 
 	const serviceData = await getServiceData(source, opts.registry);
 
-	console.log(`Retrieving current and desired config vars...`); // eslint-disable-line no-console
+	console.log('Retrieving current and desired config vars...'); // eslint-disable-line no-console
 
 	const [ desired, current ] = await Promise.all([
 		fetchFromVault(serviceData),


### PR DESCRIPTION
 🐿 v2.10.3

We wanted to be able to set our config vars on the pipeline rather than having to wait for the name of the spun up review app. Fortunately Heroku let us know about a prototype API that allowed us to do just that. Unfortunately this api is subject to change but they should give us a week's notice if this is going to happen!

Initially I tried using this prototype api to configure all stages of the pipeline but it turned that it currently only supports the 'test' stage, so I have had to keep the standard heroku api, which sets config vars directly on the staging and prod apps.

Because of this, I was going to write a separate nht task that would specifically configure review apps but I figured there wasn't a lot that would be different and so I have had a go at including it in the one configure task. If it's a bit hacky and you reckon it would be clearer in it's own nht task, I will change it.

To configure review apps on the pipeline, set the target in the command to 'review-app' e.g. `nht configure ft-next-search-page review-app`. Otherwise the command remains the same for configuring apps directly, e.g. `nht configure ft-next-search-page ft-next-search-page-eu`.

All feedback very welcome :) 


