### PR TITLE
Fail the build if the review app errors and provide link to output

### DIFF
--- a/lib/review-apps.js
+++ b/lib/review-apps.js
@@ -18,6 +18,7 @@ const REVIEW_APP_STATUSES = {
 	deleted: 'deleted',
 	creating: 'creating',
 	created: 'created',
+	failed: 'failed',
 	errored: 'errored'
 };
 const BUILD_STATUS_SUCCEEDED = 'succeeded';
@@ -68,17 +69,17 @@ const waitTillReviewAppCreated = ({ commit, minTimeout = MIN_TIMEOUT } = {}) => 
 					throw new pRetry.AbortError(`Review app was deleted: ${message}`);
 				}
 
-				if (status === REVIEW_APP_STATUSES.errored) {
+				if ((status === REVIEW_APP_STATUSES.errored) || (status === REVIEW_APP_STATUSES.failed)) {
 					try {
 						const {
 							output_stream_url
 						} = await getAppBuildWithCommit({ appId, commit });
-						console.error(`App (${appId}, commit: ${commit}) errored. For output see ${output_stream_url}`); // eslint-disable-line no-console
+						console.error(`App (${appId}, commit: ${commit}) ${status}. For output see ${output_stream_url}`); // eslint-disable-line no-console
 					} catch (e) {
 						console.error(`Could not get app build for app id ${appId}, commit: ${commit}, ${e}`); // eslint-disable-line no-console
 					}
 
-					throw new pRetry.AbortError(`Review app errored: ${message}, appId: ${appId}`);
+					throw new pRetry.AbortError(`Review app ${status}: ${message}, appId: ${appId}`);
 				}
 
 				if (status !== REVIEW_APP_STATUSES.created) {

--- a/lib/review-apps.js
+++ b/lib/review-apps.js
@@ -85,7 +85,7 @@ const waitTillReviewAppCreated = ({ commit, minTimeout = MIN_TIMEOUT } = {}) => 
 						console.error(`Could not get app build for app id ${appId}, commit: ${commit}, ${e}`); // eslint-disable-line no-console
 					}
 
-					throw new pRetry.AbortError(`Review app errored: ${message}, appId: ${appId}`);
+					throw new pRetry.AbortError(`Review app errored: (appId: ${appId}) ${message}`);
 				}
 
 				if (status !== REVIEW_APP_STATUSES.created) {

--- a/lib/review-apps.js
+++ b/lib/review-apps.js
@@ -1,5 +1,6 @@
 const pRetry = require('p-retry');
 
+const { info: pipelineInfo } = require('../lib/pipelines');
 const herokuAuthToken = require('../lib/heroku-auth-token');
 const { getGithubArchiveRedirectUrl } = require('./github-api');
 
@@ -60,14 +61,14 @@ const waitTillReviewAppCreated = ({ minTimeout = MIN_TIMEOUT } = {}) => reviewAp
 		})
 			.then(throwIfNotOk)
 			.then(res => res.json())
-			.then(data => {
-				const { status, message, app } = data;
+			.then(async data => {
+				const { status, message, app = {} } = data;
 				if (status === REVIEW_APP_STATUSES.deleted) {
 					throw new pRetry.AbortError(`Review app was deleted: ${message}`);
 				}
 
 				if (status === REVIEW_APP_STATUSES.errored) {
-					throw new pRetry.AbortError(`Review app errored: ${message}`);
+					throw new pRetry.AbortError(`Review app errored: ${message}, appId: ${app.id}`);
 				}
 
 				if (status !== REVIEW_APP_STATUSES.created) {
@@ -172,11 +173,65 @@ const createReviewApp = async ({ pipelineId, repoName, commit, branch, githubTok
 	});
 };
 
+/**
+* Get the review app name based on the review app build.
+* Create a review app if it does not exist, otherwise
+* use the existing review app and make a new build
+*
+* @param {string} appName Heroku application name
+* @param {string} repoName GitHub repository name
+* @param {string} branch GitHub branch name
+* @param {string} commit git commit SHA-1 to find the build
+* @param {string} githubToken GitHub token for getting source code
+*/
+const getReviewAppName = async ({
+	appName,
+	repoName,
+	branch,
+	commit,
+	githubToken
+}) => {
+	const { id: pipelineId } = await pipelineInfo(appName);
+
+	return createReviewApp({
+		pipelineId,
+		repoName,
+		commit,
+		branch,
+		githubToken
+	})
+		.then(res => {
+			const { status } = res;
+			if (status === 409) {
+				console.error(`Review app already created for '${branch}' branch. Using existing review app for build.`); // eslint-disable-line no-console
+				return findCreatedReviewApp({
+					pipelineId,
+					branch
+				})
+					.then(reviewApp => {
+						if (!reviewApp) {
+							throw new Error(`No review app found for pipeline ${pipelineId}, branch ${branch}`);
+						}
+
+						return reviewApp;
+					})
+					.then(waitTillReviewAppCreated())
+					.then(waitForReviewAppBuild({ commit }))
+					.then(getAppName);
+			}
+			return Promise.resolve(res)
+				.then(res => res.json())
+				.then(waitTillReviewAppCreated())
+				.then(getAppName);
+		});
+};
+
 module.exports = {
 	createReviewApp,
 	findCreatedReviewApp,
 	getAppName,
 	getBuilds,
 	waitForReviewAppBuild,
-	waitTillReviewAppCreated
+	waitTillReviewAppCreated,
+	getReviewAppName
 };

--- a/lib/review-apps.js
+++ b/lib/review-apps.js
@@ -80,7 +80,7 @@ const waitTillReviewAppCreated = ({ commit, minTimeout = MIN_TIMEOUT } = {}) => 
 						const {
 							output_stream_url
 						} = await getAppBuildWithCommit({ appId, commit });
-						console.error(`App (${appId}, commit: ${commit}) errored. For output see ${output_stream_url}`); // eslint-disable-line no-console
+						console.error(`App (${appId}, commit: ${commit}) errored.\n\nFor Heroku output see:\n${output_stream_url}`); // eslint-disable-line no-console
 					} catch (e) {
 						console.error(`Could not get app build for app id ${appId}, commit: ${commit}, ${e}`); // eslint-disable-line no-console
 					}
@@ -163,7 +163,7 @@ const waitForReviewAppBuild = ({ commit, minTimeout = MIN_TIMEOUT }) => async (a
 
 				const { status, output_stream_url } = build;
 				if ((status === BUILD_STATUSES.failed)) {
-					throw new pRetry.AbortError(`Review app build failed, appId: ${appId}, commit: ${commit}. For output see ${output_stream_url}`);
+					throw new pRetry.AbortError(`Review app build failed, appId: ${appId}, commit: ${commit}.\n\nFor Heroku output see:\n${output_stream_url}`);
 				}
 
 				if (status !== BUILD_STATUSES.succeeded) {

--- a/lib/review-apps.js
+++ b/lib/review-apps.js
@@ -16,7 +16,8 @@ const REVIEW_APP_STATUSES = {
 	pending: 'pending',
 	deleted: 'deleted',
 	creating: 'creating',
-	created: 'created'
+	created: 'created',
+	errored: 'errored'
 };
 const BUILD_STATUS_SUCCEEDED = 'succeeded';
 
@@ -63,6 +64,10 @@ const waitTillReviewAppCreated = ({ minTimeout = MIN_TIMEOUT } = {}) => reviewAp
 				const { status, message, app } = data;
 				if (status === REVIEW_APP_STATUSES.deleted) {
 					throw new pRetry.AbortError(`Review app was deleted: ${message}`);
+				}
+
+				if (status === REVIEW_APP_STATUSES.errored) {
+					throw new pRetry.AbortError(`Review app errored: ${message}`);
 				}
 
 				if (status !== REVIEW_APP_STATUSES.created) {

--- a/lib/review-apps.js
+++ b/lib/review-apps.js
@@ -52,7 +52,7 @@ const throwIfNotOk = async res => {
 	return res;
 };
 
-const waitTillReviewAppCreated = ({ minTimeout = MIN_TIMEOUT } = {}) => reviewApp => {
+const waitTillReviewAppCreated = ({ commit, minTimeout = MIN_TIMEOUT } = {}) => reviewApp => {
 	const { id } = reviewApp;
 	const checkForCreatedStatus = async () => {
 		const headers = await herokuHeaders({ useReviewAppApi: true });
@@ -63,22 +63,32 @@ const waitTillReviewAppCreated = ({ minTimeout = MIN_TIMEOUT } = {}) => reviewAp
 			.then(res => res.json())
 			.then(async data => {
 				const { status, message, app = {} } = data;
+				const appId = app.id;
 				if (status === REVIEW_APP_STATUSES.deleted) {
 					throw new pRetry.AbortError(`Review app was deleted: ${message}`);
 				}
 
 				if (status === REVIEW_APP_STATUSES.errored) {
-					throw new pRetry.AbortError(`Review app errored: ${message}, appId: ${app.id}`);
+					try {
+						const {
+							output_stream_url
+						} = await getAppBuildWithCommit({ appId, commit });
+						console.error(`App (${appId}, commit: ${commit}) errored. For output see ${output_stream_url}`); // eslint-disable-line no-console
+					} catch (e) {
+						console.error(`Could not get app build for app id ${appId}, commit: ${commit}, ${e}`); // eslint-disable-line no-console
+					}
+
+					throw new pRetry.AbortError(`Review app errored: ${message}, appId: ${appId}`);
 				}
 
 				if (status !== REVIEW_APP_STATUSES.created) {
 					const appIdOutput = (status === REVIEW_APP_STATUSES.creating)
-						? `, appId: ${app.id}`
+						? `, appId: ${appId}`
 						: '';
 					throw new Error(`Review app not created yet. Current status: ${status}${appIdOutput}`);
 				};
 
-				return app.id;
+				return appId;
 			});
 		return result;
 	};
@@ -127,23 +137,31 @@ const getBuilds = async (appId) => {
 		.then(res => res.json());
 };
 
-const waitForReviewAppBuild = ({ commit, minTimeout = MIN_TIMEOUT }) => async (appId) => {
-	const checkForBuildAppId = () => getBuilds(appId)
+const getAppBuildWithCommit = ({ appId, commit }) => {
+	return getBuilds(appId)
 		.then(builds => {
 			const build = builds.find(({ source_blob: { version } }) => version === commit);
 
-			if (!build) {
-				throw new Error(`No review app build found for app id '${appId}';, commit '${commit}'`);
-			}
-
-			const { status } = build;
-			if (status !== BUILD_STATUS_SUCCEEDED) {
-				throw new Error(`Review app build for app id '${appId}' (commit '${commit}') not done yet: ${status}`);
-			}
-
 			return build;
-		})
-		.then(({ app: { id } }) => id);
+		});
+};
+
+const waitForReviewAppBuild = ({ commit, minTimeout = MIN_TIMEOUT }) => async (appId) => {
+	const checkForBuildAppId = () =>
+		getAppBuildWithCommit({ commit, appId })
+			.then(build => {
+				if (!build) {
+					throw new Error(`No review app build found for app id '${appId}';, commit '${commit}'`);
+				}
+
+				const { status } = build;
+				if (status !== BUILD_STATUS_SUCCEEDED) {
+					throw new Error(`Review app build for app id '${appId}' (commit '${commit}') not done yet: ${status}`);
+				}
+
+				return build;
+			})
+			.then(({ app: { id } }) => id);
 
 	return pRetry(checkForBuildAppId, {
 		factor: RETRY_EXP_BACK_OFF_FACTOR,
@@ -215,13 +233,13 @@ const getReviewAppName = async ({
 
 						return reviewApp;
 					})
-					.then(waitTillReviewAppCreated())
+					.then(waitTillReviewAppCreated({ commit }))
 					.then(waitForReviewAppBuild({ commit }))
 					.then(getAppName);
 			}
 			return Promise.resolve(res)
 				.then(res => res.json())
-				.then(waitTillReviewAppCreated())
+				.then(waitTillReviewAppCreated({ commit }))
 				.then(getAppName);
 		});
 };
@@ -231,6 +249,7 @@ module.exports = {
 	findCreatedReviewApp,
 	getAppName,
 	getBuilds,
+	getAppBuildWithCommit,
 	waitForReviewAppBuild,
 	waitTillReviewAppCreated,
 	getReviewAppName

--- a/lib/review-apps.js
+++ b/lib/review-apps.js
@@ -63,7 +63,7 @@ const waitTillReviewAppCreated = ({ commit, minTimeout = MIN_TIMEOUT } = {}) => 
 			.then(res => res.json())
 			.then(async data => {
 				const { status, message, app = {} } = data;
-				const appId = app.id;
+				const appId = !!app ? app.id : undefined;
 				if (status === REVIEW_APP_STATUSES.deleted) {
 					throw new pRetry.AbortError(`Review app was deleted: ${message}`);
 				}

--- a/lib/review-apps.js
+++ b/lib/review-apps.js
@@ -18,11 +18,11 @@ const REVIEW_APP_STATUSES = {
 	deleted: 'deleted',
 	creating: 'creating',
 	created: 'created',
-	failed: 'failed',
 	errored: 'errored'
 };
 const BUILD_STATUSES = {
-	succeeded: 'succeeded'
+	succeeded: 'succeeded',
+	failed: 'failed'
 };
 
 const getReviewAppUrl = reviewAppId => `https://api.heroku.com/review-apps/${reviewAppId}`;
@@ -71,17 +71,21 @@ const waitTillReviewAppCreated = ({ commit, minTimeout = MIN_TIMEOUT } = {}) => 
 					throw new pRetry.AbortError(`Review app was deleted: ${message}`);
 				}
 
-				if ((status === REVIEW_APP_STATUSES.errored) || (status === REVIEW_APP_STATUSES.failed)) {
+				if ((status === REVIEW_APP_STATUSES.errored)) {
+					if (!appId) {
+						throw new pRetry.AbortError(`Review app errored: ${message}`);
+					}
+
 					try {
 						const {
 							output_stream_url
 						} = await getAppBuildWithCommit({ appId, commit });
-						console.error(`App (${appId}, commit: ${commit}) ${status}. For output see ${output_stream_url}`); // eslint-disable-line no-console
+						console.error(`App (${appId}, commit: ${commit}) errored. For output see ${output_stream_url}`); // eslint-disable-line no-console
 					} catch (e) {
 						console.error(`Could not get app build for app id ${appId}, commit: ${commit}, ${e}`); // eslint-disable-line no-console
 					}
 
-					throw new pRetry.AbortError(`Review app ${status}: ${message}, appId: ${appId}`);
+					throw new pRetry.AbortError(`Review app errored: ${message}, appId: ${appId}`);
 				}
 
 				if (status !== REVIEW_APP_STATUSES.created) {
@@ -152,12 +156,16 @@ const getAppBuildWithCommit = ({ appId, commit }) => {
 const waitForReviewAppBuild = ({ commit, minTimeout = MIN_TIMEOUT }) => async (appId) => {
 	const checkForBuildAppId = () =>
 		getAppBuildWithCommit({ commit, appId })
-			.then(build => {
+			.then(async build => {
 				if (!build) {
 					throw new Error(`No review app build found for app id '${appId}';, commit '${commit}'`);
 				}
 
-				const { status } = build;
+				const { status, output_stream_url } = build;
+				if ((status === BUILD_STATUSES.failed)) {
+					throw new pRetry.AbortError(`Review app build failed, appId: ${appId}, commit: ${commit}. For output see ${output_stream_url}`);
+				}
+
 				if (status !== BUILD_STATUSES.succeeded) {
 					throw new Error(`Review app build for app id '${appId}' (commit '${commit}') not done yet: ${status}`);
 				}

--- a/lib/review-apps.js
+++ b/lib/review-apps.js
@@ -21,7 +21,9 @@ const REVIEW_APP_STATUSES = {
 	failed: 'failed',
 	errored: 'errored'
 };
-const BUILD_STATUS_SUCCEEDED = 'succeeded';
+const BUILD_STATUSES = {
+	succeeded: 'succeeded'
+};
 
 const getReviewAppUrl = reviewAppId => `https://api.heroku.com/review-apps/${reviewAppId}`;
 const getPipelineReviewAppsUrl = pipelineId => `https://api.heroku.com/pipelines/${pipelineId}/review-apps`;
@@ -156,7 +158,7 @@ const waitForReviewAppBuild = ({ commit, minTimeout = MIN_TIMEOUT }) => async (a
 				}
 
 				const { status } = build;
-				if (status !== BUILD_STATUS_SUCCEEDED) {
+				if (status !== BUILD_STATUSES.succeeded) {
 					throw new Error(`Review app build for app id '${appId}' (commit '${commit}') not done yet: ${status}`);
 				}
 

--- a/lib/review-apps.unit.test.js
+++ b/lib/review-apps.unit.test.js
@@ -598,30 +598,12 @@ describe('review-apps', () => {
 			const reviewAppId = 'reviewAppId';
 			const appId = 'app123';
 
-			nockScope.get('/pipelines/next-app')
+			nockScope
+				.get('/pipelines/next-app')
 				.reply(200, {
 					id: pipelineId
-				});
-			reviewAppsNockScope.post('/review-apps')
-				.reply(409, {
-					id: 'conflict',
-					message: 'A review app already exists for the post-build branch'
-				});
-			reviewAppsNockScope.get('/pipelines/pipelineId/review-apps')
-				.reply(200, [
-					{
-						id: reviewAppId,
-						branch
-					}
-				]);
-			reviewAppsNockScope.get('/review-apps/reviewAppId')
-				.reply(200, {
-					status: 'created',
-					app: {
-						id: appId
-					}
-				});
-			nockScope.get('/apps/app123/builds')
+				})
+				.get('/apps/app123/builds')
 				.reply(200, [
 					{
 						status: 'succeeded',
@@ -632,10 +614,30 @@ describe('review-apps', () => {
 							version: commit
 						}
 					}
-				]);
-			nockScope.get('/apps/app123')
+				])
+				.get('/apps/app123')
 				.reply(200, {
 					name: appName
+				});
+			reviewAppsNockScope
+				.post('/review-apps')
+				.reply(409, {
+					id: 'conflict',
+					message: 'A review app already exists for the post-build branch'
+				})
+				.get('/pipelines/pipelineId/review-apps')
+				.reply(200, [
+					{
+						id: reviewAppId,
+						branch
+					}
+				])
+				.get('/review-apps/reviewAppId')
+				.reply(200, {
+					status: 'created',
+					app: {
+						id: appId
+					}
 				});
 
 			const name = await getReviewAppName({
@@ -664,19 +666,20 @@ describe('review-apps', () => {
 				.reply(200, {
 					id: pipelineId
 				});
-			reviewAppsNockScope.post('/review-apps')
+			reviewAppsNockScope
+				.post('/review-apps')
 				.reply(409, {
 					id: 'conflict',
 					message: 'A review app already exists for the post-build branch'
-				});
-			reviewAppsNockScope.get('/pipelines/pipelineId/review-apps')
+				})
+				.get('/pipelines/pipelineId/review-apps')
 				.reply(200, [
 					{
 						id: reviewAppId,
 						branch
 					}
-				]);
-			reviewAppsNockScope.get('/review-apps/reviewAppId')
+				])
+				.get('/review-apps/reviewAppId')
 				.reply(200, {
 					status: 'deleted',
 					app: {
@@ -712,19 +715,20 @@ describe('review-apps', () => {
 				.reply(200, {
 					id: pipelineId
 				});
-			reviewAppsNockScope.post('/review-apps')
+			reviewAppsNockScope
+				.post('/review-apps')
 				.reply(409, {
 					id: 'conflict',
 					message: 'A review app already exists for the post-build branch'
-				});
-			reviewAppsNockScope.get('/pipelines/pipelineId/review-apps')
+				})
+				.get('/pipelines/pipelineId/review-apps')
 				.reply(200, [
 					{
 						id: reviewAppId,
 						branch
 					}
-				]);
-			reviewAppsNockScope.get('/review-apps/reviewAppId')
+				])
+				.get('/review-apps/reviewAppId')
 				.reply(200, {
 					status: 'errored',
 					app: {
@@ -757,25 +761,27 @@ describe('review-apps', () => {
 			const reviewAppId = 'reviewAppId';
 			const appId = 'app123';
 
-			nockScope.get('/pipelines/next-app')
+			nockScope
+				.get('/pipelines/next-app')
 				.reply(200, {
 					id: pipelineId
+				})
+				.get('/apps/app123')
+				.reply(200, {
+					name: appName
 				});
-			reviewAppsNockScope.post('/review-apps')
+			reviewAppsNockScope
+				.post('/review-apps')
 				.reply(200, {
 					id: reviewAppId,
 					status: 'created'
-				});
-			reviewAppsNockScope.get('/review-apps/reviewAppId')
+				})
+				.get('/review-apps/reviewAppId')
 				.reply(200, {
 					status: 'created',
 					app: {
 						id: appId
 					}
-				});
-			nockScope.get('/apps/app123')
-				.reply(200, {
-					name: appName
 				});
 
 			const name = await getReviewAppName({

--- a/lib/review-apps.unit.test.js
+++ b/lib/review-apps.unit.test.js
@@ -17,7 +17,7 @@ describe('review-apps', () => {
 
 		// WARNING: Disable error logs, to clean up test output
 		// Re-enable here if need be
-		jest.spyOn(console, 'error').mockImplementation();
+		jest.spyOn(console, 'error').mockImplementation().mockName('console.error');
 	});
 
 	afterAll(() => {
@@ -27,6 +27,7 @@ describe('review-apps', () => {
 
 	afterEach(() => {
 		nock.cleanAll();
+		jest.resetAllMocks();
 	});
 
 	describe('createReviewApp', () => {
@@ -185,6 +186,48 @@ describe('review-apps', () => {
 			} catch (error) {
 				expect(error.message).toEqual('Some error occurred');
 			}
+		});
+	});
+
+	describe('getAppBuildWithCommit', () => {
+		const { getAppBuildWithCommit } = reviewApps;
+		it('returns build', async () => {
+			const appId = 'app123';
+			const commit = 'ababa';
+			nockScope.get('/apps/app123/builds')
+				.reply(200, [
+					{
+						source_blob: {
+							version: commit
+						}
+					}
+				]);
+			const build = await getAppBuildWithCommit({ appId, commit });
+			expect(build).toBeTruthy();
+		});
+
+		it('returns undefined if there is no build with the commit', async () => {
+			const appId = 'app123';
+			const commit = 'ababa';
+			nockScope.get('/apps/app123/builds')
+				.reply(200, [
+					{
+						source_blob: {
+							version: 'wrong commit'
+						}
+					}
+				]);
+			const build = await getAppBuildWithCommit({ appId, commit });
+			expect(build).toBeFalsy();
+		});
+
+		it('returns undefined if there is no builds', async () => {
+			const appId = 'app123';
+			const commit = 'ababa';
+			nockScope.get('/apps/app123/builds')
+				.reply(200, []);
+			const build = await getAppBuildWithCommit({ appId, commit });
+			expect(build).toBeFalsy();
 		});
 	});
 
@@ -391,7 +434,7 @@ describe('review-apps', () => {
 			expect(waitedReviewAppBuild).toEqual(appId);
 		});
 
-		it('throws error if review app is deleted', async () => {
+		it('throws error if review app status is deleted', async () => {
 			const reviewAppId = 'reviewApp123';
 			const reviewApp = {
 				id: reviewAppId
@@ -408,7 +451,7 @@ describe('review-apps', () => {
 				});
 		});
 
-		it('throws error if review app errors', async () => {
+		it('throws error if review app status is errored', async () => {
 			const reviewAppId = 'reviewApp123';
 			const reviewApp = {
 				id: reviewAppId
@@ -422,6 +465,57 @@ describe('review-apps', () => {
 				.catch(error => {
 					const { message } = error;
 					expect(message).toMatch('Review app errored');
+				});
+		});
+
+		it('logs output stream url if review app status is errored', async () => {
+			const appId = 'app123';
+			const reviewAppId = 'reviewApp123';
+			const reviewApp = {
+				id: reviewAppId
+			};
+			const commit = 'ababab';
+			reviewAppsNockScope.get('/review-apps/reviewApp123')
+				.reply(200, {
+					app: {
+						id: appId
+					},
+					status: 'errored'
+				});
+			nockScope.get('/apps/app123/builds')
+				.reply(200, [
+					{
+						app: {
+							id: appId
+						},
+						source_blob: {
+							version: commit
+						},
+						output_stream_url: 'https://heroku.com/builds/output/app123'
+					}
+				]);
+
+			return waitTillReviewAppCreated({ commit })(reviewApp)
+				.catch(() => {
+					expect(console.error.mock.calls[0][0]).toMatch('https://heroku.com/builds/output/app123'); // eslint-disable-line no-console
+				});
+		});
+
+		it('logs error if review app status is errored and build endpoint errors', async () => {
+			const reviewAppId = 'reviewApp123';
+			const reviewApp = {
+				id: reviewAppId
+			};
+			reviewAppsNockScope.get('/review-apps/reviewApp123')
+				.reply(200, {
+					status: 'errored'
+				});
+			nockScope.get('/apps/app123/builds')
+				.reply(400);
+
+			return waitTillReviewAppCreated()(reviewApp)
+				.catch(() => {
+					expect(console.error.mock.calls[0][0]).toMatch('Could not get app build'); // eslint-disable-line no-console
 				});
 		});
 

--- a/lib/review-apps.unit.test.js
+++ b/lib/review-apps.unit.test.js
@@ -408,6 +408,23 @@ describe('review-apps', () => {
 				});
 		});
 
+		it('throws error if review app errors', async () => {
+			const reviewAppId = 'reviewApp123';
+			const reviewApp = {
+				id: reviewAppId
+			};
+			reviewAppsNockScope.get('/review-apps/reviewApp123')
+				.reply(200, {
+					status: 'errored'
+				});
+
+			return waitTillReviewAppCreated()(reviewApp)
+				.catch(error => {
+					const { message } = error;
+					expect(message).toMatch('Review app errored');
+				});
+		});
+
 		it('times out', async () => {
 			const reviewAppId = 'reviewApp123';
 			const reviewApp = {

--- a/lib/review-apps.unit.test.js
+++ b/lib/review-apps.unit.test.js
@@ -340,6 +340,32 @@ describe('review-apps', () => {
 			expect(waitedReviewAppBuild).toEqual(appId);
 		});
 
+		it('fails for failed review app build with output stream link', async () => {
+			const commit = 'a00000000000';
+			const appId = 'app123';
+			const failedReviewAppBuild = {
+				source_blob: {
+					version: commit
+				},
+				status: 'failed',
+				output_stream_url: 'https://heroku.com/builds/output/app123'
+			};
+			nockScope
+				.get('/apps/app123/builds')
+				.reply(200, [ failedReviewAppBuild ]);
+
+			try {
+				await waitForReviewAppBuild({
+					commit,
+					minTimeout: 0
+				})(appId);
+			} catch (e) {
+				const { message } = e;
+				expect(message).toMatch('Review app build failed');
+				expect(message).toMatch('https://heroku.com/builds/output/app123');
+			}
+		});
+
 		it('times out', async () => {
 			const commit = 'a00000000000';
 			const appId = 'app123';
@@ -468,24 +494,6 @@ describe('review-apps', () => {
 				});
 		});
 
-		it('throws error if review app status is failed', async () => {
-			const reviewAppId = 'reviewApp123';
-			const reviewApp = {
-				id: reviewAppId
-			};
-			reviewAppsNockScope.get('/review-apps/reviewApp123')
-				.reply(200, {
-					status: 'failed'
-				});
-
-			return waitTillReviewAppCreated()(reviewApp)
-				.catch(error => {
-					const { message } = error;
-					expect(message).toMatch('Review app failed');
-				});
-		});
-
-
 		it('can error if app is null', async () => {
 			const reviewAppId = 'reviewApp123';
 			const reviewApp = {
@@ -538,14 +546,17 @@ describe('review-apps', () => {
 		});
 
 		it('logs error if review app status is errored and build endpoint errors', async () => {
+			const appId = 'app123';
 			const reviewAppId = 'reviewApp123';
 			const reviewApp = {
-				id: reviewAppId
+				app: {
+					id: appId
+				},
+				id: reviewAppId,
+				status: 'errored'
 			};
 			reviewAppsNockScope.get('/review-apps/reviewApp123')
-				.reply(200, {
-					status: 'errored'
-				});
+				.reply(200, reviewApp);
 			nockScope.get('/apps/app123/builds')
 				.reply(400);
 

--- a/lib/review-apps.unit.test.js
+++ b/lib/review-apps.unit.test.js
@@ -468,6 +468,24 @@ describe('review-apps', () => {
 				});
 		});
 
+		it('throws error if review app status is failed', async () => {
+			const reviewAppId = 'reviewApp123';
+			const reviewApp = {
+				id: reviewAppId
+			};
+			reviewAppsNockScope.get('/review-apps/reviewApp123')
+				.reply(200, {
+					status: 'failed'
+				});
+
+			return waitTillReviewAppCreated()(reviewApp)
+				.catch(error => {
+					const { message } = error;
+					expect(message).toMatch('Review app failed');
+				});
+		});
+
+
 		it('can error if app is null', async () => {
 			const reviewAppId = 'reviewApp123';
 			const reviewApp = {

--- a/lib/review-apps.unit.test.js
+++ b/lib/review-apps.unit.test.js
@@ -442,4 +442,210 @@ describe('review-apps', () => {
 				});
 		});
 	});
+
+	describe('getReviewAppName', () => {
+		const { getReviewAppName } = reviewApps;
+
+		it('creates a new review app build if a review app already exists', async () => {
+			const appName = 'next-app';
+			const repoName = 'next-app-repo';
+			const branch = 'new-idea-branch';
+			const commit = 'a123';
+			const githubToken = 'github-token-123';
+
+			const pipelineId = 'pipelineId';
+			const reviewAppId = 'reviewAppId';
+			const appId = 'app123';
+
+			nockScope.get('/pipelines/next-app')
+				.reply(200, {
+					id: pipelineId
+				});
+			reviewAppsNockScope.post('/review-apps')
+				.reply(409, {
+					id: 'conflict',
+					message: 'A review app already exists for the post-build branch'
+				});
+			reviewAppsNockScope.get('/pipelines/pipelineId/review-apps')
+				.reply(200, [
+					{
+						id: reviewAppId,
+						branch
+					}
+				]);
+			reviewAppsNockScope.get('/review-apps/reviewAppId')
+				.reply(200, {
+					status: 'created',
+					app: {
+						id: appId
+					}
+				});
+			nockScope.get('/apps/app123/builds')
+				.reply(200, [
+					{
+						status: 'succeeded',
+						app: {
+							id: appId
+						},
+						source_blob: {
+							version: commit
+						}
+					}
+				]);
+			nockScope.get('/apps/app123')
+				.reply(200, {
+					name: appName
+				});
+
+			const name = await getReviewAppName({
+				appName,
+				repoName,
+				branch,
+				commit,
+				githubToken
+			});
+
+			expect(name).toEqual(appName);
+		});
+
+		it('throws an error if review app is deleted', async () => {
+			const appName = 'next-app';
+			const repoName = 'next-app-repo';
+			const branch = 'new-idea-branch';
+			const commit = 'a123';
+			const githubToken = 'github-token-123';
+
+			const pipelineId = 'pipelineId';
+			const reviewAppId = 'reviewAppId';
+			const appId = 'app123';
+
+			nockScope.get('/pipelines/next-app')
+				.reply(200, {
+					id: pipelineId
+				});
+			reviewAppsNockScope.post('/review-apps')
+				.reply(409, {
+					id: 'conflict',
+					message: 'A review app already exists for the post-build branch'
+				});
+			reviewAppsNockScope.get('/pipelines/pipelineId/review-apps')
+				.reply(200, [
+					{
+						id: reviewAppId,
+						branch
+					}
+				]);
+			reviewAppsNockScope.get('/review-apps/reviewAppId')
+				.reply(200, {
+					status: 'deleted',
+					app: {
+						id: appId
+					}
+				});
+
+			try {
+				await getReviewAppName({
+					appName,
+					repoName,
+					branch,
+					commit,
+					githubToken
+				});
+			} catch ({ message }) {
+				expect(message).toMatch('Review app was deleted');
+			}
+		});
+
+		it('throws an error if review app errors', async () => {
+			const appName = 'next-app';
+			const repoName = 'next-app-repo';
+			const branch = 'new-idea-branch';
+			const commit = 'a123';
+			const githubToken = 'github-token-123';
+
+			const pipelineId = 'pipelineId';
+			const reviewAppId = 'reviewAppId';
+			const appId = 'app123';
+
+			nockScope.get('/pipelines/next-app')
+				.reply(200, {
+					id: pipelineId
+				});
+			reviewAppsNockScope.post('/review-apps')
+				.reply(409, {
+					id: 'conflict',
+					message: 'A review app already exists for the post-build branch'
+				});
+			reviewAppsNockScope.get('/pipelines/pipelineId/review-apps')
+				.reply(200, [
+					{
+						id: reviewAppId,
+						branch
+					}
+				]);
+			reviewAppsNockScope.get('/review-apps/reviewAppId')
+				.reply(200, {
+					status: 'errored',
+					app: {
+						id: appId
+					}
+				});
+
+			try {
+				await getReviewAppName({
+					appName,
+					repoName,
+					branch,
+					commit,
+					githubToken
+				});
+			} catch ({ message }) {
+				expect(message).toMatch('Review app errored');
+				expect(message).toMatch(appId);
+			}
+		});
+
+		it('gets review app name', async () => {
+			const appName = 'next-app';
+			const repoName = 'next-app-repo';
+			const branch = 'new-idea-branch';
+			const commit = 'a123';
+			const githubToken = 'github-token-123';
+
+			const pipelineId = 'pipelineId';
+			const reviewAppId = 'reviewAppId';
+			const appId = 'app123';
+
+			nockScope.get('/pipelines/next-app')
+				.reply(200, {
+					id: pipelineId
+				});
+			reviewAppsNockScope.post('/review-apps')
+				.reply(200, {
+					id: reviewAppId,
+					status: 'created'
+				});
+			reviewAppsNockScope.get('/review-apps/reviewAppId')
+				.reply(200, {
+					status: 'created',
+					app: {
+						id: appId
+					}
+				});
+			nockScope.get('/apps/app123')
+				.reply(200, {
+					name: appName
+				});
+
+			const name = await getReviewAppName({
+				appName,
+				repoName,
+				branch,
+				commit,
+				githubToken
+			});
+
+			expect(name).toEqual(appName);
+		});
+	});
 });

--- a/lib/review-apps.unit.test.js
+++ b/lib/review-apps.unit.test.js
@@ -410,7 +410,7 @@ describe('review-apps', () => {
 			expect(waitedReviewAppBuild).toEqual(appId);
 		});
 
-		it('waits for review app id even if there is an error', async () => {
+		it('waits for review app id even if there is a http error', async () => {
 			const appId = 'app123';
 			const reviewAppId = 'reviewApp123';
 			const reviewApp = {
@@ -458,6 +458,24 @@ describe('review-apps', () => {
 			};
 			reviewAppsNockScope.get('/review-apps/reviewApp123')
 				.reply(200, {
+					status: 'errored'
+				});
+
+			return waitTillReviewAppCreated()(reviewApp)
+				.catch(error => {
+					const { message } = error;
+					expect(message).toMatch('Review app errored');
+				});
+		});
+
+		it('can error if app is null', async () => {
+			const reviewAppId = 'reviewApp123';
+			const reviewApp = {
+				id: reviewAppId
+			};
+			reviewAppsNockScope.get('/review-apps/reviewApp123')
+				.reply(200, {
+					app: null,
 					status: 'errored'
 				});
 

--- a/tasks/review-app.js
+++ b/tasks/review-app.js
@@ -1,42 +1,17 @@
-const { info: pipelineInfo } = require('../lib/pipelines');
 const {
-	createReviewApp,
-	findCreatedReviewApp,
-	waitTillReviewAppCreated,
-	waitForReviewAppBuild,
-	getAppName
+	getReviewAppName
 } = require('../lib/review-apps');
 
 async function task (appName, options) {
 	const { repoName, branch, commit, githubToken } = options;
-	const { id: pipelineId } = await pipelineInfo(appName);
 
-	return createReviewApp({ pipelineId, repoName, commit, branch, githubToken })
-		.then(res => {
-			const { status } = res;
-			if (status === 409) {
-				console.error(`Review app already created for '${branch}' branch. Using existing review app for build.`); // eslint-disable-line no-console
-				return findCreatedReviewApp({
-					pipelineId,
-					branch
-				})
-					.then(reviewApp => {
-						if (!reviewApp) {
-							throw new Error(`No review app found for pipeline ${pipelineId}, branch ${branch}`);
-						}
-
-						return reviewApp;
-					})
-					.then(waitTillReviewAppCreated())
-					.then(waitForReviewAppBuild({ commit }))
-					.then(getAppName);
-			}
-			return Promise.resolve(res)
-				.then(res => res.json())
-				.then(waitTillReviewAppCreated())
-				.then(getAppName);
-		})
-		.then(appName => {
+	return getReviewAppName({
+			appName,
+			repoName,
+			branch,
+			commit,
+			githubToken
+		}).then(appName => {
 			console.log(appName); // eslint-disable-line no-console
 		});
 }

--- a/tasks/review-app.js
+++ b/tasks/review-app.js
@@ -30,7 +30,8 @@ module.exports = function (program) {
 			try {
 				await task(appName, options);
 			} catch (error) {
-				console.error(error); // eslint-disable-line no-console
+				const { message } = error || {};
+				console.error(message, error); // eslint-disable-line no-console
 				process.exit(1);
 				return;
 			}

--- a/tasks/review-app.js
+++ b/tasks/review-app.js
@@ -31,7 +31,7 @@ module.exports = function (program) {
 				await task(appName, options);
 			} catch (error) {
 				const { message } = error || {};
-				console.error(message, error); // eslint-disable-line no-console
+				console.error(`${message}\n\n`, error); // eslint-disable-line no-console
 				process.exit(1);
 				return;
 			}


### PR DESCRIPTION
There are 2 situations where review apps fail:

* Newly recreated review apps - this produces a status of `errored` when the review app gets created
* Existing review apps - the status of the review app is `created`, but the build of the review app will have a status of `failed`

In the above situations, the CircleCI build will output a link to the Heroku log eg,

```
Review app already created for 'chores/trying-out-error-builds' branch. Using existing review app for build.
Review app build failed, appId: 409a50dc-ff01-45dd-8bd2-2c3aea4ccaae, commit: 7ad258ba226570f7e83072d0d5b9641252a07acb.

For Heroku output see:
https://build-output.heroku.com/streams/40/409a50dc-ff01-45dd-8bd2-2c3aea4ccaae/logs/71/71768dfd-6051-4912-b30a-49fcba8e93f9.log?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIQI6BAUWXGR4S77Q%2F20181129%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20181129T152708Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=3c8be83133001a06d7e7b7753671fc6f33a06c346b6f06f8f64d6693188fdab8

 Error
    at getAppBuildWithCommit.then (/home/circleci/project/build/node_modules/@financial-times/n-heroku-tools/lib/review-apps.js:166:12)
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:229:7)
```

Fixes https://github.com/Financial-Times/n-heroku-tools/issues/534

### TODO

* [x] Test this on a repo
  * [x] Normal build - https://circleci.com/gh/Financial-Times/next-search-page/2265
  * [x] Deleted build (same as "Review app `errored`")
  * [x] Review app `errored` - https://circleci.com/gh/Financial-Times/next-search-page/2258 (fail `heroku-postbuild`)
  * [x] Review app build `failed` - https://circleci.com/gh/Financial-Times/next-search-page/2283 (put `Makefile` in `.slugignore`, delete the build and rebuild)