### PR TITLE
Use --team not --org

### DIFF
--- a/lib/pipelines.js
+++ b/lib/pipelines.js
@@ -51,7 +51,7 @@ function getApps (pipelineName){
 
 function create (pipelineName, { stagingApp, organisation }){
 	let command = 'heroku';
-	let args = ['pipelines:create', pipelineName, '--org', organisation, '--stage', 'staging', '--app', stagingApp];
+	let args = ['pipelines:create', pipelineName, '--team', organisation, '--stage', 'staging', '--app', stagingApp];
 
 	return new Promise((resolve, reject) =>{
 		let ps = spawn(command, args, { env:process.env, stdio:'inherit' });

--- a/tasks/provision.js
+++ b/tasks/provision.js
@@ -4,7 +4,7 @@ const DEFAULT_REGION = 'us';
 const DEFAULT_ORG = 'ft-customer-products';
 
 function task (name, { region = DEFAULT_REGION, organisation = DEFAULT_ORG } = {}) {
-	return spawn(`heroku create -a ${name} --region ${region} --org ${organisation} --no-remote`, { verbose: true });
+	return spawn(`heroku create -a ${name} --region ${region} --team ${organisation} --no-remote`, { verbose: true });
 };
 
 module.exports = function (program, utils) {


### PR DESCRIPTION
To be tagged as `v7.10.2`.

Heroku have stopped accepting `--org` as an argument.

Related pull request on the Heroku CLI https://github.com/heroku/cli/pull/1187.