### PR TITLE
Override default maximum size of HTTP headers

### DIFF
--- a/tasks/run.js
+++ b/tasks/run.js
@@ -101,6 +101,16 @@ function runScript (opts) {
 		if (opts.subargs) {
 			args = args.concat(opts.subargs.replace(/^\[/, '').replace(/]$/, '').split(','));
 		}
+
+		/**
+		 * The default maximum size of HTTP headers is 8KB.
+		 * To override the default, we must pass in the --max-http-header-size option
+		 * and specify a maximum size.
+		 *
+		 * @see https://nodejs.org/docs/latest-v8.x/api/cli.html#cli_max_http_header_size_size
+		 */
+		args.unshift('--max-http-header-size=80000');
+
 		return ['node', args, { cwd: process.cwd(), env: env }];
 	});
 }


### PR DESCRIPTION
Node.js 8.14.0 introduced a maximum size for HTTP headers of 8KB. This ended up breaking a lot of our apps because our header sizes are much larger. In Node.js 8.15.0, you can specify a different maximum size using the `--max-http-header-size` option.

While adding a smoke test to next-router to test the maximum header size, we found that the test wasn't passing locally because of `nht run`. Turns out we need to add the `node --max-http-header-size=80000` option when starting node and that's what this PR does!

Resolves https://github.com/Financial-Times/n-heroku-tools/issues/552