### PR TITLE
Make S3 paths configurable via CLI flag

### DIFF
--- a/lib/normalize-name.spec.js
+++ b/lib/normalize-name.spec.js
@@ -1,0 +1,26 @@
+var normalize = require("./normalize-name");
+
+describe("normalize", () => {
+  it("removes ft prefixes without options", () => {
+    var alpha = normalize("ft-alpha");
+    var beta = normalize("next-beta");
+    var gamma = normalize("@financial-times/gamma");
+    
+    expect(alpha).toBe("alpha");
+    expect(beta).toBe("beta");
+    expect(gamma).toBe("@financial-times/gamma");
+  });
+  it("removes ft prefixes and versions", () => {
+    var alpha = normalize("ft-alpha-v1", { version: false });
+    var beta = normalize("next-beta-v99", { version: false });
+    var gamma = normalize("ft-gamma-v123", { version: false });
+    var delta = normalize("next-delta-v123", { version: false });
+    var epsilon = normalize("@financial-times/epsilon", { version: false });
+
+    expect(alpha).toBe("alpha-v1");
+    expect(beta).toBe("beta-v99");
+    expect(gamma).toBe("gamma");
+    expect(delta).toBe("delta");
+    expect(epsilon).toBe("epsilon");
+  });
+});

--- a/lib/normalize-name.unit.test.js
+++ b/lib/normalize-name.unit.test.js
@@ -1,16 +1,17 @@
 var normalize = require("./normalize-name");
 
-describe("normalize", () => {
-  it("removes ft prefixes without options", () => {
+describe("normalize", function() {
+  it("removes ft prefixes without options", function() {
     var alpha = normalize("ft-alpha");
     var beta = normalize("next-beta");
     var gamma = normalize("@financial-times/gamma");
-    
+
     expect(alpha).toBe("alpha");
     expect(beta).toBe("beta");
     expect(gamma).toBe("@financial-times/gamma");
   });
-  it("removes ft prefixes and versions", () => {
+
+  it("removes ft prefixes and versions", function() {
     var alpha = normalize("ft-alpha-v1", { version: false });
     var beta = normalize("next-beta-v99", { version: false });
     var gamma = normalize("ft-gamma-v123", { version: false });

--- a/tasks/deploy-hashed-assets.js
+++ b/tasks/deploy-hashed-assets.js
@@ -7,7 +7,6 @@ const readFile = denodeify(require('fs').readFile);
 const waitForOk = require('../lib/wait-for-ok');
 const path = require('path');
 const aws = require('aws-sdk');
-const fs = require('fs');
 
 const AWS_ACCESS_HASHED_ASSETS = process.env.AWS_ACCESS_HASHED_ASSETS || process.env.aws_access_hashed_assets;
 const AWS_SECRET_HASHED_ASSETS = process.env.AWS_SECRET_HASHED_ASSETS || process.env.aws_secret_hashed_assets;

--- a/tasks/deploy-hashed-assets.js
+++ b/tasks/deploy-hashed-assets.js
@@ -1,132 +1,155 @@
-'use strict';
+"use strict";
 
-const packageJson = require(process.cwd() + '/package.json');
-const denodeify = require('denodeify');
-const normalizeName = require('../lib/normalize-name');
-const readFile = denodeify(require('fs').readFile);
-const waitForOk = require('../lib/wait-for-ok');
-const path = require('path');
-const aws = require('aws-sdk');
+const packageJson = require(process.cwd() + "/package.json");
+const denodeify = require("denodeify");
+const normalizeName = require("../lib/normalize-name");
+const readFile = denodeify(require("fs").readFile);
+const waitForOk = require("../lib/wait-for-ok");
+const path = require("path");
+const aws = require("aws-sdk");
+const fs = require("fs");
 
-const AWS_ACCESS_HASHED_ASSETS = process.env.AWS_ACCESS_HASHED_ASSETS || process.env.aws_access_hashed_assets;
-const AWS_SECRET_HASHED_ASSETS = process.env.AWS_SECRET_HASHED_ASSETS || process.env.aws_secret_hashed_assets;
+const AWS_ACCESS_HASHED_ASSETS =
+  process.env.AWS_ACCESS_HASHED_ASSETS || process.env.aws_access_hashed_assets;
+const AWS_SECRET_HASHED_ASSETS =
+  process.env.AWS_SECRET_HASHED_ASSETS || process.env.aws_secret_hashed_assets;
 
-const euBucket = 'ft-next-hashed-assets-prod';
-const usBucket = 'ft-next-hashed-assets-prod-us';
-const euRegion = 'eu-west-1';
-const usRegion = 'us-east-1';
-const gzip = denodeify(require('zlib').gzip);
+const euBucket = "ft-next-hashed-assets-prod";
+const usBucket = "ft-next-hashed-assets-prod-us";
+const euRegion = "eu-west-1";
+const usRegion = "us-east-1";
+const gzip = denodeify(require("zlib").gzip);
 
+function task(opts) {
+  aws.config.update({
+    accessKeyId: AWS_ACCESS_HASHED_ASSETS,
+    secretAccessKey: AWS_SECRET_HASHED_ASSETS,
+    euRegion
+  });
 
-function task (opts) {
+  function upload(bucket, params) {
+    const s3Bucket = new aws.S3({ params: { Bucket: bucket } });
+    return new Promise((resolve, reject) => {
+      return s3Bucket.upload(params, (err, data) => {
+        if (err) {
+          console.error(`Upload failed to ${bucket}`, err); // eslint-disable-line no-console
+          reject(err);
+        } else {
+          console.log(`Upload success to ${bucket}`, data); // eslint-disable-line no-console
+          resolve();
+        }
+      });
+    });
+  }
 
-	aws.config.update({
-		accessKeyId: AWS_ACCESS_HASHED_ASSETS,
-		secretAccessKey: AWS_SECRET_HASHED_ASSETS,
-		euRegion
-	});
+  const shouldMonitorAssets = opts.monitorAssets;
+  const directory = opts.directory || "public";
+  const appName =
+    normalizeName(opts.app) ||
+    normalizeName(packageJson.name, { version: false });
 
-	function upload (bucket, params) {
+  let assetHashes;
 
-		const s3Bucket = new aws.S3({ params: { Bucket: bucket } });
-		return new Promise((resolve, reject) => {
-			return s3Bucket.upload(params, (err, data) => {
-						if (err) {
-							console.error(`Upload failed to ${bucket}`, err); // eslint-disable-line no-console
-							reject(err);
-						} else {
-							console.log(`Upload success to ${bucket}`, data); // eslint-disable-line no-console
-							resolve();
-						}
-					});
-				});
-	}
+  try {
+    console.log(process.cwd() + `/${directory}/assets-hashes.json`); // eslint-disable-line no-console
+    assetHashes = require(process.cwd() + `/${directory}/asset-hashes.json`);
+  } catch (err) {
+    return Promise.reject(
+      "Must run `make build-production` before running `nbt deploy-hashed-assets`"
+    );
+  }
 
-	const shouldMonitorAssets = opts.monitorAssets;
-	const directory = opts.directory || 'public';
-	let assetHashes;
-	try {
-		console.log(process.cwd() + `/${directory}/assets-hashes.json`); // eslint-disable-line no-console
-		assetHashes = require(process.cwd() + `/${directory}/asset-hashes.json`);
-	} catch(err) {
-		return Promise.reject('Must run `make build-production` before running `nbt deploy-hashed-assets`');
-	}
+  if (!(AWS_ACCESS_HASHED_ASSETS && AWS_SECRET_HASHED_ASSETS)) {
+    return Promise.reject(
+      "Must set AWS_ACCESS_HASHED_ASSETS and AWS_SECRET_HASHED_ASSETS"
+    );
+  }
 
-	if (!(AWS_ACCESS_HASHED_ASSETS && AWS_SECRET_HASHED_ASSETS)) {
-		return Promise.reject('Must set AWS_ACCESS_HASHED_ASSETS and AWS_SECRET_HASHED_ASSETS');
-	}
+  console.log("Deploying hashed assets to S3..."); // eslint-disable-line no-console
 
-	const app = normalizeName(packageJson.name, { version: false });
+  return Promise.all(
+    Object.keys(assetHashes).map(file => {
+      const hashedName = assetHashes[file];
+      const key = "hashed-assets/" + appName + "/" + hashedName;
+      // get the extension, ignoring brotli
+      const extension = (/\.(js|css)(\.br)?$/.exec(file) || [])[1];
 
-	console.log('Deploying hashed assets to S3...'); // eslint-disable-line no-console
+      console.log(`sending ${key} to S3`); // eslint-disable-line no-console
 
-	return Promise.all(Object.keys(assetHashes)
-			.map(file => {
-				const hashedName = assetHashes[file];
-				const key = 'hashed-assets/' + app + '/' + hashedName;
-				// get the extension, ignoring brotli
-				const extension = (/\.(js|css)(\.br)?$/.exec(file) || [])[1];
+      return readFile(path.join(process.cwd(), directory, file), {
+        encoding: "utf-8"
+      }).then(content => {
+        // ignore source maps
+        const isMonitoringAsset =
+          shouldMonitorAssets && path.extname(file) !== ".map";
+        let params = {
+          Key: key,
+          Body: content,
+          ACL: "public-read",
+          CacheControl: opts.cacheControl || "public, max-age=31536000"
+        };
 
-				console.log(`sending ${key} to S3`); // eslint-disable-line no-console
+        if (opts.surrogateControl) {
+          params.Metadata = {
+            "Surrogate-Control": opts.surrogateControl
+          };
+        }
 
-				return readFile(path.join(process.cwd(), directory, file), { encoding: 'utf-8' })
-					.then(content => {
-						// ignore source maps
-						const isMonitoringAsset = shouldMonitorAssets && path.extname(file) !== '.map';
-						let params = {
-							Key: key,
-							Body: content,
-							ACL: 'public-read',
-							CacheControl: opts.cacheControl || 'public, max-age=31536000'
-						};
-
-						if (opts.surrogateControl) {
-							params.Metadata = {
-								'Surrogate-Control': opts.surrogateControl
-							};
-						}
-
-						switch(extension) {
-							case 'js':
-								params.ContentType = 'text/javascript; charset=utf-8';
-								break;
-							case 'css':
-								params.ContentType = 'text/css; charset=utf-8';
-								break;
-						}
-						return Promise.all([
-							upload(euBucket, params),
-							upload(usBucket, params)
-						])
-							.then(() => Promise.all([
-								waitForOk(`http://${euBucket}.s3-website-${euRegion}.amazonaws.com/${key}`),
-								waitForOk(`http://${usBucket}.s3-website-${usRegion}.amazonaws.com/${key}`),
-								isMonitoringAsset ? gzip(content) : Promise.resolve()
-							]))
-							.then(values => {
-								if (!isMonitoringAsset) {
-									return;
-								}
-								const contentSize = Buffer.byteLength(content);
-								const gzippedContentSize = Buffer.byteLength(values[2]);
-								console.log(`${file} is ${contentSize} bytes (${gzippedContentSize} bytes gzipped)`); // eslint-disable-line no-console
-							});
-					});
-			})
-		);
+        switch (extension) {
+          case "js":
+            params.ContentType = "text/javascript; charset=utf-8";
+            break;
+          case "css":
+            params.ContentType = "text/css; charset=utf-8";
+            break;
+        }
+        return Promise.all([upload(euBucket, params), upload(usBucket, params)])
+          .then(() =>
+            Promise.all([
+              waitForOk(
+                `http://${euBucket}.s3-website-${euRegion}.amazonaws.com/${key}`
+              ),
+              waitForOk(
+                `http://${usBucket}.s3-website-${usRegion}.amazonaws.com/${key}`
+              ),
+              isMonitoringAsset ? gzip(content) : Promise.resolve()
+            ])
+          )
+          .then(values => {
+            if (!isMonitoringAsset) {
+              return;
+            }
+            const contentSize = Buffer.byteLength(content);
+            const gzippedContentSize = Buffer.byteLength(values[2]);
+            console.log(
+              `${file} is ${contentSize} bytes (${gzippedContentSize} bytes gzipped)`
+            ); // eslint-disable-line no-console
+          });
+      });
+    })
+  );
 }
 
-module.exports = function (program, utils) {
-	program
-		.command('deploy-hashed-assets')
-		.description('deploys hashed asset files to S3 (if AWS keys set correctly)')
-		.option('--monitor-assets', 'Will send asset sizes to Graphite')
-		.option('--directory <directory>', 'Directory to deploy (defaults to public)')
-		.option('--cache-control <cacheControl>', 'Optionally specify a cache control value')
-		.option('--surrogate-control <cacheControl>', 'Optionally specify a surrogate control value')
-		.action(function (options) {
-			task(options).catch(utils.exit);
-		});
+module.exports = function(program, utils) {
+  program
+    .command("deploy-hashed-assets")
+    .description("deploys hashed asset files to S3 (if AWS keys set correctly)")
+    .option("--monitor-assets", "Will send asset sizes to Graphite")
+    .option(
+      "--directory <directory>",
+      "Directory to deploy (defaults to public)"
+    )
+    .option(
+      "--cache-control <cacheControl>",
+      "Optionally specify a cache control value"
+    )
+    .option(
+      "--surrogate-control <cacheControl>",
+      "Optionally specify a surrogate control value"
+    )
+    .action(function(options) {
+      task(options).catch(utils.exit);
+    });
 };
 
 module.exports.task = task;

--- a/tasks/deploy-hashed-assets.js
+++ b/tasks/deploy-hashed-assets.js
@@ -1,155 +1,137 @@
-"use strict";
+'use strict';
 
-const packageJson = require(process.cwd() + "/package.json");
-const denodeify = require("denodeify");
-const normalizeName = require("../lib/normalize-name");
-const readFile = denodeify(require("fs").readFile);
-const waitForOk = require("../lib/wait-for-ok");
-const path = require("path");
-const aws = require("aws-sdk");
-const fs = require("fs");
+const packageJson = require(process.cwd() + '/package.json');
+const denodeify = require('denodeify');
+const normalizeName = require('../lib/normalize-name');
+const readFile = denodeify(require('fs').readFile);
+const waitForOk = require('../lib/wait-for-ok');
+const path = require('path');
+const aws = require('aws-sdk');
+const fs = require('fs');
 
-const AWS_ACCESS_HASHED_ASSETS =
-  process.env.AWS_ACCESS_HASHED_ASSETS || process.env.aws_access_hashed_assets;
-const AWS_SECRET_HASHED_ASSETS =
-  process.env.AWS_SECRET_HASHED_ASSETS || process.env.aws_secret_hashed_assets;
+const AWS_ACCESS_HASHED_ASSETS = process.env.AWS_ACCESS_HASHED_ASSETS || process.env.aws_access_hashed_assets;
+const AWS_SECRET_HASHED_ASSETS = process.env.AWS_SECRET_HASHED_ASSETS || process.env.aws_secret_hashed_assets;
 
-const euBucket = "ft-next-hashed-assets-prod";
-const usBucket = "ft-next-hashed-assets-prod-us";
-const euRegion = "eu-west-1";
-const usRegion = "us-east-1";
-const gzip = denodeify(require("zlib").gzip);
+const euBucket = 'ft-next-hashed-assets-prod';
+const usBucket = 'ft-next-hashed-assets-prod-us';
+const euRegion = 'eu-west-1';
+const usRegion = 'us-east-1';
+const gzip = denodeify(require('zlib').gzip);
 
-function task(opts) {
-  aws.config.update({
-    accessKeyId: AWS_ACCESS_HASHED_ASSETS,
-    secretAccessKey: AWS_SECRET_HASHED_ASSETS,
-    euRegion
-  });
+function task (opts) {
 
-  function upload(bucket, params) {
-    const s3Bucket = new aws.S3({ params: { Bucket: bucket } });
-    return new Promise((resolve, reject) => {
-      return s3Bucket.upload(params, (err, data) => {
-        if (err) {
-          console.error(`Upload failed to ${bucket}`, err); // eslint-disable-line no-console
-          reject(err);
-        } else {
-          console.log(`Upload success to ${bucket}`, data); // eslint-disable-line no-console
-          resolve();
-        }
-      });
-    });
-  }
+	aws.config.update({
+		accessKeyId: AWS_ACCESS_HASHED_ASSETS,
+		secretAccessKey: AWS_SECRET_HASHED_ASSETS,
+		euRegion
+	});
 
-  const shouldMonitorAssets = opts.monitorAssets;
-  const directory = opts.directory || "public";
-  const appName =
-    normalizeName(opts.app) ||
-    normalizeName(packageJson.name, { version: false });
+	function upload (bucket, params) {
 
-  let assetHashes;
+		const s3Bucket = new aws.S3({ params: { Bucket: bucket } });
+		return new Promise((resolve, reject) => {
+			return s3Bucket.upload(params, (err, data) => {
+						if (err) {
+							console.error(`Upload failed to ${bucket}`, err); // eslint-disable-line no-console
+							reject(err);
+						} else {
+							console.log(`Upload success to ${bucket}`, data); // eslint-disable-line no-console
+							resolve();
+						}
+					});
+				});
+	}
 
-  try {
-    console.log(process.cwd() + `/${directory}/assets-hashes.json`); // eslint-disable-line no-console
-    assetHashes = require(process.cwd() + `/${directory}/asset-hashes.json`);
-  } catch (err) {
-    return Promise.reject(
-      "Must run `make build-production` before running `nbt deploy-hashed-assets`"
-    );
-  }
+	const shouldMonitorAssets = opts.monitorAssets;
+	const directory = opts.directory || 'public';
+	const appName = 
+		normalizeName(opts.app) || 
+		normalizeName(packageJson.name, { version: false });
 
-  if (!(AWS_ACCESS_HASHED_ASSETS && AWS_SECRET_HASHED_ASSETS)) {
-    return Promise.reject(
-      "Must set AWS_ACCESS_HASHED_ASSETS and AWS_SECRET_HASHED_ASSETS"
-    );
-  }
+	let assetHashes;
+	
+	try {
+		console.log(process.cwd() + `/${directory}/assets-hashes.json`); // eslint-disable-line no-console
+		assetHashes = require(process.cwd() + `/${directory}/asset-hashes.json`);
+	} catch(err) {
+		return Promise.reject('Must run `make build-production` before running `nbt deploy-hashed-assets`');
+	}
 
-  console.log("Deploying hashed assets to S3..."); // eslint-disable-line no-console
+	if (!(AWS_ACCESS_HASHED_ASSETS && AWS_SECRET_HASHED_ASSETS)) {
+		return Promise.reject('Must set AWS_ACCESS_HASHED_ASSETS and AWS_SECRET_HASHED_ASSETS');
+	}
 
-  return Promise.all(
-    Object.keys(assetHashes).map(file => {
-      const hashedName = assetHashes[file];
-      const key = "hashed-assets/" + appName + "/" + hashedName;
-      // get the extension, ignoring brotli
-      const extension = (/\.(js|css)(\.br)?$/.exec(file) || [])[1];
+	
 
-      console.log(`sending ${key} to S3`); // eslint-disable-line no-console
+	console.log('Deploying hashed assets to S3...'); // eslint-disable-line no-console
 
-      return readFile(path.join(process.cwd(), directory, file), {
-        encoding: "utf-8"
-      }).then(content => {
-        // ignore source maps
-        const isMonitoringAsset =
-          shouldMonitorAssets && path.extname(file) !== ".map";
-        let params = {
-          Key: key,
-          Body: content,
-          ACL: "public-read",
-          CacheControl: opts.cacheControl || "public, max-age=31536000"
-        };
+	return Promise.all(Object.keys(assetHashes)
+			.map(file => {
+				const hashedName = assetHashes[file];
+				const key = 'hashed-assets/' + appName + '/' + hashedName;
+				// get the extension, ignoring brotli
+				const extension = (/\.(js|css)(\.br)?$/.exec(file) || [])[1];
 
-        if (opts.surrogateControl) {
-          params.Metadata = {
-            "Surrogate-Control": opts.surrogateControl
-          };
-        }
+				console.log(`sending ${key} to S3`); // eslint-disable-line no-console
 
-        switch (extension) {
-          case "js":
-            params.ContentType = "text/javascript; charset=utf-8";
-            break;
-          case "css":
-            params.ContentType = "text/css; charset=utf-8";
-            break;
-        }
-        return Promise.all([upload(euBucket, params), upload(usBucket, params)])
-          .then(() =>
-            Promise.all([
-              waitForOk(
-                `http://${euBucket}.s3-website-${euRegion}.amazonaws.com/${key}`
-              ),
-              waitForOk(
-                `http://${usBucket}.s3-website-${usRegion}.amazonaws.com/${key}`
-              ),
-              isMonitoringAsset ? gzip(content) : Promise.resolve()
-            ])
-          )
-          .then(values => {
-            if (!isMonitoringAsset) {
-              return;
-            }
-            const contentSize = Buffer.byteLength(content);
-            const gzippedContentSize = Buffer.byteLength(values[2]);
-            console.log(
-              `${file} is ${contentSize} bytes (${gzippedContentSize} bytes gzipped)`
-            ); // eslint-disable-line no-console
-          });
-      });
-    })
-  );
+				return readFile(path.join(process.cwd(), directory, file), { encoding: 'utf-8' })
+					.then(content => {
+						// ignore source maps
+						const isMonitoringAsset = shouldMonitorAssets && path.extname(file) !== '.map';
+						let params = {
+							Key: key,
+							Body: content,
+							ACL: 'public-read',
+							CacheControl: opts.cacheControl || 'public, max-age=31536000'
+						};
+
+						if (opts.surrogateControl) {
+							params.Metadata = {
+								'Surrogate-Control': opts.surrogateControl
+							};
+						}
+
+						switch(extension) {
+							case 'js':
+								params.ContentType = 'text/javascript; charset=utf-8';
+								break;
+							case 'css':
+								params.ContentType = 'text/css; charset=utf-8';
+								break;
+						}
+						return Promise.all([
+							upload(euBucket, params),
+							upload(usBucket, params)
+						])
+							.then(() => Promise.all([
+								waitForOk(`http://${euBucket}.s3-website-${euRegion}.amazonaws.com/${key}`),
+								waitForOk(`http://${usBucket}.s3-website-${usRegion}.amazonaws.com/${key}`),
+								isMonitoringAsset ? gzip(content) : Promise.resolve()
+							]))
+							.then(values => {
+								if (!isMonitoringAsset) {
+									return;
+								}
+								const contentSize = Buffer.byteLength(content);
+								const gzippedContentSize = Buffer.byteLength(values[2]);
+								console.log(`${file} is ${contentSize} bytes (${gzippedContentSize} bytes gzipped)`); // eslint-disable-line no-console
+							});
+					});
+			})
+		);
 }
 
-module.exports = function(program, utils) {
-  program
-    .command("deploy-hashed-assets")
-    .description("deploys hashed asset files to S3 (if AWS keys set correctly)")
-    .option("--monitor-assets", "Will send asset sizes to Graphite")
-    .option(
-      "--directory <directory>",
-      "Directory to deploy (defaults to public)"
-    )
-    .option(
-      "--cache-control <cacheControl>",
-      "Optionally specify a cache control value"
-    )
-    .option(
-      "--surrogate-control <cacheControl>",
-      "Optionally specify a surrogate control value"
-    )
-    .action(function(options) {
-      task(options).catch(utils.exit);
-    });
+module.exports = function (program, utils) {
+	program
+		.command('deploy-hashed-assets')
+		.description('deploys hashed asset files to S3 (if AWS keys set correctly)')
+		.option('--monitor-assets', 'Will send asset sizes to Graphite')
+		.option('--directory <directory>', 'Directory to deploy (defaults to public)')
+		.option('--cache-control <cacheControl>', 'Optionally specify a cache control value')
+		.option('--surrogate-control <cacheControl>', 'Optionally specify a surrogate control value')
+		.action(function (options) {
+			task(options).catch(utils.exit);
+		});
 };
 
 module.exports.task = task;


### PR DESCRIPTION
Currently, hashed assets are written to `/hashed-assets/${appName}/hashedName` where `appName` is read from `package.json`. This PR adds support for a command line flag `--app` to provide a custom value.

This will allow N-Gage to deploy the assets of Anvil-based apps to `/hashed-assets/anvil/hashedName` so that modules common across apps can be cached client-side.

This PR addresses issue #551. A companion PR to N-Gage is in flight.

 🐿 v2.12.0