### PR TITLE
Handle rejected promises in the gtg task

### DIFF
--- a/tasks/gtg.js
+++ b/tasks/gtg.js
@@ -1,12 +1,17 @@
 const host = require('../lib/host');
 const waitForOk = require('../lib/wait-for-ok');
 
-module.exports = function (program) {
+module.exports = function (program, utils) {
 	program
 		.command('gtg [app]')
 		.description('Runs gtg checks for an app')
-		.action(function (app) {
+		.action(async (app) => {
 			const url = `${host.url(app)}/__gtg`;
-			return waitForOk(url);
+		
+			try {
+				return await waitForOk(url);
+			} catch (err) {
+				utils.exit(err);
+			}
 		});
 };


### PR DESCRIPTION
This pull request should also be paired with a change to n-gage, to ensure that we still delete review apps on the master branch even if the `__gtg` checks fail and exit the build correctly.

Or we could convert the CircleCI builds so that there is a `finally`/`tidy` build step that always runs.

https://github.com/Financial-Times/n-gage/blob/bc762c2eff50d17ecdd7e3a934a228d881c7f465/src/tasks/review-app.mk#L32-L43

Resolves https://github.com/Financial-Times/n-heroku-tools/issues/555.