### PR TITLE
Replace ft.yml with CODEOWNERS file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,13 +22,13 @@ references:
 
   npm_cache_keys: &npm_cache_keys
     keys:
-        - v1-dependency-npm-{{ checksum "package.json" }}-
-        - v1-dependency-npm-{{ checksum "package.json" }}
-        - v1-dependency-npm-
+        - v2-dependency-npm-{{ checksum "package.json" }}-
+        - v2-dependency-npm-{{ checksum "package.json" }}
+        - v2-dependency-npm-
 
   cache_npm_cache: &cache_npm_cache
     save_cache:
-        key: v1-dependency-npm-{{ checksum "package.json" }}-{{ epoch }}
+        key: v2-dependency-npm-{{ checksum "package.json" }}-{{ epoch }}
         paths:
         - ./node_modules/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,13 +22,13 @@ references:
 
   npm_cache_keys: &npm_cache_keys
     keys:
-        - v2-dependency-npm-{{ checksum "package.json" }}-
-        - v2-dependency-npm-{{ checksum "package.json" }}
-        - v2-dependency-npm-
+        - v10-dependency-npm-{{ checksum "package.json" }}-
+        - v10-dependency-npm-{{ checksum "package.json" }}
+        - v10-dependency-npm-
 
   cache_npm_cache: &cache_npm_cache
     save_cache:
-        key: v2-dependency-npm-{{ checksum "package.json" }}-{{ epoch }}
+        key: v10-dependency-npm-{{ checksum "package.json" }}-{{ epoch }}
         paths:
         - ./node_modules/
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# See https://help.github.com/articles/about-codeowners/ for more information about this file.
+
+* arjun.gadhia@ft.com

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # See https://help.github.com/articles/about-codeowners/ for more information about this file.
 
-* arjun.gadhia@ft.com
+* bren.brightwell@ft.com

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,7 @@ unit-test:
 unit-test-watch:
 	jest --watch
 
-minus-eslint: ci-n-ui-check _verify_lintspaces _verify_pa11y_testable
-
-test: minus-eslint unit-test
+test: verify unit-test
 
 docs:
 	./scripts/generate-docs.sh > README.md

--- a/ft.yml
+++ b/ft.yml
@@ -1,3 +1,0 @@
-owner:
-  github: adgad
-  email: arjun.gadhia@ft.com

--- a/lib/normalize-name.unit.test.js
+++ b/lib/normalize-name.unit.test.js
@@ -1,27 +1,27 @@
-var normalize = require("./normalize-name");
+const normalize = require('./normalize-name');
 
-describe("normalize", function() {
-  it("removes ft prefixes without options", function() {
-    var alpha = normalize("ft-alpha");
-    var beta = normalize("next-beta");
-    var gamma = normalize("@financial-times/gamma");
+describe('normalize', function () {
+	it('removes ft prefixes without options', function () {
+		const alpha = normalize('ft-alpha');
+		const beta = normalize('next-beta');
+		const gamma = normalize('@financial-times/gamma');
 
-    expect(alpha).toBe("alpha");
-    expect(beta).toBe("beta");
-    expect(gamma).toBe("@financial-times/gamma");
-  });
+		expect(alpha).toBe('alpha');
+		expect(beta).toBe('beta');
+		expect(gamma).toBe('@financial-times/gamma');
+	});
 
-  it("removes ft prefixes and versions", function() {
-    var alpha = normalize("ft-alpha-v1", { version: false });
-    var beta = normalize("next-beta-v99", { version: false });
-    var gamma = normalize("ft-gamma-v123", { version: false });
-    var delta = normalize("next-delta-v123", { version: false });
-    var epsilon = normalize("@financial-times/epsilon", { version: false });
+	it('removes ft prefixes and versions', function () {
+		const alpha = normalize('ft-alpha-v1', { version: false });
+		const beta = normalize('next-beta-v99', { version: false });
+		const gamma = normalize('ft-gamma-v123', { version: false });
+		const delta = normalize('next-delta-v123', { version: false });
+		const epsilon = normalize('@financial-times/epsilon', { version: false });
 
-    expect(alpha).toBe("alpha-v1");
-    expect(beta).toBe("beta-v99");
-    expect(gamma).toBe("gamma");
-    expect(delta).toBe("delta");
-    expect(epsilon).toBe("epsilon");
-  });
+		expect(alpha).toBe('alpha-v1');
+		expect(beta).toBe('beta-v99');
+		expect(gamma).toBe('gamma');
+		expect(delta).toBe('delta');
+		expect(epsilon).toBe('epsilon');
+	});
 });

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "shellpromise": "^1.0.0"
   },
   "devDependencies": {
-    "@financial-times/n-gage": "^2.0.4",
+    "@financial-times/n-gage": "^3.6.0",
     "body-parser": "^1.14.1",
     "eslint": "^2.8.0",
     "lintspaces-cli": "^0.1.1",

--- a/tasks/deploy-hashed-assets.js
+++ b/tasks/deploy-hashed-assets.js
@@ -44,11 +44,11 @@ function task (opts) {
 	const shouldMonitorAssets = opts.monitorAssets;
 	const directory = opts.directory || 'public';
 	const appName = opts.app
-		? normalizeName(opts.app) 
+		? normalizeName(opts.app)
 		: normalizeName(packageJson.name, { version: false });
 
 	let assetHashes;
-	
+
 	try {
 		console.log(process.cwd() + `/${directory}/assets-hashes.json`); // eslint-disable-line no-console
 		assetHashes = require(process.cwd() + `/${directory}/asset-hashes.json`);
@@ -60,7 +60,7 @@ function task (opts) {
 		return Promise.reject('Must set AWS_ACCESS_HASHED_ASSETS and AWS_SECRET_HASHED_ASSETS');
 	}
 
-	
+
 
 	console.log('Deploying hashed assets to S3...'); // eslint-disable-line no-console
 

--- a/tasks/run.js
+++ b/tasks/run.js
@@ -103,12 +103,12 @@ function runScript (opts) {
 		}
 
 		/**
-		 * The default maximum size of HTTP headers is 8KB.
-		 * To override the default, we must pass in the --max-http-header-size option
-		 * and specify a maximum size.
-		 *
-		 * @see https://nodejs.org/docs/latest-v8.x/api/cli.html#cli_max_http_header_size_size
-		 */
+		* The default maximum size of HTTP headers is 8KB.
+		* To override the default, we must pass in the --max-http-header-size option
+		* and specify a maximum size.
+		*
+		* @see https://nodejs.org/docs/latest-v8.x/api/cli.html#cli_max_http_header_size_size
+		*/
 		args.unshift('--max-http-header-size=80000');
 
 		return ['node', args, { cwd: process.cwd(), env: env }];


### PR DESCRIPTION
This PR replaces our custom `ft.yml` file with GitHub's standard CODEOWNERS file. The CODEOWNERS file defines the individual or team that is responsible for the code in the repository. Unlike `ft.yml`, code owners will automatically be asked to review any pull requests.

For more information on CODEOWNERS, see https://help.github.com/en/articles/about-code-owners.

Where a repository contains an empty `ft.yml`, no CODEOWNERS file will be created. We did this so we can easily identify which repositories are unowned by looking for the absence of a CODEOWNERS file.

The n-gage package insists that repositories have an ft.yml file. Version 3.4.0 of n-gage removes this requirement. This transformation requires n-gage version 3.4.0 in package.json because it deletes the (otherwise required) ft.yml file.
