### PR TITLE
save response text/json on heroku errors

### DIFF
--- a/lib/heroku-api.js
+++ b/lib/heroku-api.js
@@ -22,7 +22,15 @@ function herokuApi ({ endpoint, authToken, options = {} }) {
 			let err = new Error(`BadResponse: ${url} - ${status} ${statusText}`);
 			err.name = 'BAD_RESPONSE';
 			err.status = status;
-			throw err;
+			return response.text().then(text => {
+				try {
+					err.responseJson = JSON.parse(text);
+				} catch(_) {
+					err.repsonseText = text;
+				}
+
+				throw err;
+			});
 		}
 
 		return response.json();


### PR DESCRIPTION
- try and parse it as json but don't use `response.json` up front in case it's not
- i don't know if this is safe ie i would hope heroku isn't echoing our sensitive data eg config vars in errors but who knows