### PR TITLE
Fix nodemon node_modules ignore.

### DIFF
--- a/tasks/run.js
+++ b/tasks/run.js
@@ -79,7 +79,7 @@ function runLocal (opts) {
 
 		if(opts.nodemon) {
 			args.push('--ignore', 'public/');
-			args.push('--ignore', 'node-modules/');
+			args.push('--ignore', 'node_modules/');
 			return ['nodemon', args, { cwd: process.cwd(), env: env }];
 		} else {
 			return ['node', args, { cwd: process.cwd(), env: env }];


### PR DESCRIPTION
In the process of investigating another issue, I've discovered that this line was incorrect.

A side effect of this will be that the app won't restart automatically for any changes made in local projects that have been `npm link`ed.