### PR TITLE
Add REDIS_URL to list of forbidden variables

### DIFF
--- a/tasks/configure.js
+++ b/tasks/configure.js
@@ -9,7 +9,8 @@ const pipelines = require('../lib/pipelines');
 const HerokuConfigVars = require('../lib/heroku-config-vars');
 
 const FORBIDDEN_ATTACHMENT_VARIABLES = [
-	'DATABASE_URL'
+	'DATABASE_URL',
+	'REDIS_URL'
 ];
 
 const DEFAULT_REGISTRY_URI = 'https://next-registry.ft.com/v2/';


### PR DESCRIPTION
The REDIS_URL environment variables is set by the Heroku Redis add-on (https://devcenter.heroku.com/articles/heroku-redis#create-a-new-instance). Setting the variable in Vault will cause problems when the value changes.