### PR TITLE
Update README to reference common usage of NHT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# n-heroku-tools
+# nht (n-heroku-tools)
 
 This library is a command line tool that orchestrates [Heroku](https://www.heroku.com/) and [Amazon S3](https://aws.amazon.com/s3/) deployments for [Next](https://github.com/Financial-Times/next/wiki), based on configuration in the [Next service registry](https://next-registry.ft.com/v2/) and [Vault](https://www.vaultproject.io/).
 
 ### Installation
 
-In order to use this tool, run
+To install `nht`, run:
 
 ```
 npm install @financial-times/n-heroku-tools --save-dev
@@ -12,10 +12,10 @@ npm install @financial-times/n-heroku-tools --save-dev
 
 ### Usage
 
-In order to use `n-heroku-tools` the following commands are available in your command line:
+Use `nht` or `n-heroku-tools` on the command line:
 
 ```
-Usage: n-heroku-tools [options] [command]
+Usage: nht [options] [command]
 
 Options:
   -V, --version                                       output the version number

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# nht (n-heroku-tools)
+# n-heroku-tools (nht)
 
 This library is a command line tool that orchestrates [Heroku](https://www.heroku.com/) and [Amazon S3](https://aws.amazon.com/s3/) deployments for [Next](https://github.com/Financial-Times/next/wiki), based on configuration in the [Next service registry](https://next-registry.ft.com/v2/) and [Vault](https://www.vaultproject.io/).
 
 ### Installation
 
-To install `nht`, run:
+To install `n-heroku-tools`, run:
 
 ```
 npm install @financial-times/n-heroku-tools --save-dev


### PR DESCRIPTION
As a newcomer it was confusing me if this repository was for `nht` which I see across the applications.

Default the repository to the common usecase while referencing the expanded name.