### PR TITLE
Upgrade node engine from 8.x to 10.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,15 @@
 
 references:
 
-  container_config_node8: &container_config_node8
+  container_config_node10: &container_config_node10
     working_directory: ~/project/build
     docker:
-      - image: circleci/node:8-browsers
+      - image: circleci/node:10-browsers
 
-  container_config_lambda_node8: &container_config_lambda_node8
+  container_config_lambda_node10: &container_config_lambda_node10
     working_directory: ~/project/build
     docker:
-      - image: lambci/lambda:build-nodejs8.10
+      - image: lambci/lambda:build-nodejs10.x
 
   workspace_root: &workspace_root
     ~/project
@@ -60,7 +60,7 @@ version: 2
 jobs:
 
   build:
-    <<: *container_config_node8
+    <<: *container_config_node10
     steps:
       - checkout
       - run:
@@ -90,7 +90,7 @@ jobs:
             - build
 
   test:
-    <<: *container_config_node8
+    <<: *container_config_node10
     steps:
       - *attach_workspace
       - run:
@@ -106,7 +106,7 @@ jobs:
           destination: test-results
 
   publish:
-    <<: *container_config_node8
+    <<: *container_config_node10
     steps:
       - *attach_workspace
       - run:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@financial-times/n-heroku-tools",
   "version": "0.0.0",
   "engines": {
-    "node": "^8.9.0"
+    "node": "10.x"
   },
   "bin": {
     "n-heroku-tools": "./bin/n-heroku-tools.js",


### PR DESCRIPTION
Many Next apps are using this on Node 12 so I'm confident it works regardless, but I'd like to install it in ft-app which enforces engine-strict = true and runs Node 10.

Unit tests pass on Node 10 and will run on CircleCI.

I just need one release that supports Node 10 and then I'm happy for someone to let it run on Node 12 if they'd like to.

Node 8 is end-of-life as of 1 Jan 2020 so I think we're happy to drop support for it.