### PR TITLE
Delete and rebuild review apps missing build

### DIFF
--- a/lib/__mocks__/github-api.js
+++ b/lib/__mocks__/github-api.js
@@ -1,5 +1,3 @@
 module.exports = {
-	getGithubArchiveRedirectUrl: jest.fn(() => {
-		return Promise.resolve('https://github.com/some-tarball-link');
-	})
+	getGithubArchiveRedirectUrl: () => Promise.resolve('https://github.com/some-tarball-link')
 };

--- a/lib/review-apps.js
+++ b/lib/review-apps.js
@@ -120,27 +120,26 @@ const waitTillReviewAppCreated = async ({ commit, reviewApp, minTimeout = MIN_TI
 		retries: NUM_RETRIES,
 		minTimeout,
 		onFailedAttempt: error => {
+
 			const { attemptNumber, message } = error;
 			console.error(`${attemptNumber}/${NUM_RETRIES}: ${message}`); // eslint-disable-line no-console
 		}
 	});
 };
 
-const handleWaitTillReviewAppCreated = async ({ commit, reviewApp }) => {
-
-	let appId;
+const handleWaitTillReviewAppCreated = async ({ commit, reviewApp, minTimeout = MIN_TIMEOUT }) => {
 
 	try {
 
-		appId = await waitTillReviewAppCreated({ commit, reviewApp });
+		const appId = await waitTillReviewAppCreated({ commit, reviewApp, minTimeout });
+
+		return appId;
 
 	} catch (error) {
 
 		throw new pRetry.AbortError(error);
 
 	}
-
-	return appId;
 
 };
 
@@ -240,11 +239,11 @@ const awaitReviewAppBuild = async ({ commit, appId, minTimeout = MIN_TIMEOUT }) 
 
 };
 
-const handleNonSucceededReviewAppBuild = async ({ commit, appId }) => {
+const handleNonSucceededReviewAppBuild = async ({ commit, appId, minTimeout = MIN_TIMEOUT }) => {
 
 	try {
 
-		await awaitReviewAppBuild({ commit, appId });
+		await awaitReviewAppBuild({ commit, appId, minTimeout });
 
 	} catch (error) {
 
@@ -319,7 +318,7 @@ const getReviewAppName = async ({ appName, repoName, branch, commit, githubToken
 
 			if (status === BUILD_STATUSES.failed) throw new pRetry.AbortError(`Review app build failed, appId: ${appId}, commit: ${commit}.\n\nFor Heroku output see:\n${output_stream_url}`);
 
-			if (status !== BUILD_STATUSES.succeeded) await handleNonSucceededReviewAppBuild({ commit, appId });
+			if (status !== BUILD_STATUSES.succeeded) await handleNonSucceededReviewAppBuild({ commit, appId, minTimeout });
 
 			const appName = await getAppName(appId);
 
@@ -350,9 +349,12 @@ const getReviewAppName = async ({ appName, repoName, branch, commit, githubToken
 };
 
 module.exports = {
+	handleNonSucceededReviewAppBuild,
 	createReviewApp,
 	findCreatedReviewApp,
+	handleWaitTillReviewAppCreated,
 	getAppName,
+	deleteReviewApp,
 	getBuilds,
 	getAppBuildWithCommit,
 	awaitReviewAppBuild,

--- a/lib/review-apps.js
+++ b/lib/review-apps.js
@@ -10,6 +10,7 @@ const DEFAULT_HEADERS = {
 	'Content-Type': 'application/json'
 };
 
+const CONFLICT_STATUS_CODE = 409;
 const GET_REVIEW_APP_NAME_NUM_RETRIES = 1;
 const NUM_RETRIES = 60;
 const RETRY_EXP_BACK_OFF_FACTOR = 1;
@@ -31,188 +32,226 @@ const getPipelineReviewAppsUrl = pipelineId => `https://api.heroku.com/pipelines
 const getAppUrl = appId => `https://api.heroku.com/apps/${appId}`;
 const getBuildsUrl = appId => `https://api.heroku.com/apps/${appId}/builds`;
 
-function herokuHeaders ({ useReviewAppApi } = {}) {
-	const defaultHeaders = useReviewAppApi
-		? Object.assign({}, DEFAULT_HEADERS, {
-			Accept: 'application/vnd.heroku+json; version=3.review-apps',
-		})
-		: DEFAULT_HEADERS;
-	return herokuAuthToken()
-		.then(key => {
-			return {
-				...defaultHeaders,
-				Authorization: `Bearer ${key}`
-			};
-		});
-}
+const herokuHeaders = async ({ useReviewAppApi } = {}) => {
 
-const throwIfNotOk = async res => {
-	const { ok, status, url } = res;
-	if (!ok) {
-		const errorBody = await res.json();
-		console.error('Fetch error:', status, url, errorBody); // eslint-disable-line no-console
-		throw new Error(errorBody.message);
-	}
-	return res;
+	const defaultHeaders = useReviewAppApi
+		? Object.assign({}, DEFAULT_HEADERS, { Accept: 'application/vnd.heroku+json; version=3.review-apps' })
+		: DEFAULT_HEADERS;
+
+	const key = await herokuAuthToken();
+
+	return {
+		...defaultHeaders,
+		Authorization: `Bearer ${key}`
+	};
+
 };
 
-const waitTillReviewAppCreated = ({ commit, minTimeout = MIN_TIMEOUT } = {}) => reviewApp => {
-	const reviewAppId = reviewApp.id;
+const throwIfNotOk = async response => {
+
+	const { ok, status, url } = response;
+
+	if (!ok) {
+
+		const errorBody = await response.json();
+
+		console.error('Fetch error:', status, url, errorBody); // eslint-disable-line no-console
+
+		throw new Error(errorBody.message);
+
+	}
+
+	return response;
+
+};
+
+const waitTillReviewAppCreated = async ({ commit, reviewApp, minTimeout = MIN_TIMEOUT } = {}) => {
+
 	const checkForCreatedStatus = async () => {
+
 		const headers = await herokuHeaders({ useReviewAppApi: true });
-		const result = await fetch(getReviewAppUrl(reviewAppId), {
-			headers
-		})
-			.then(throwIfNotOk)
-			.then(res => res.json())
-			.then(async data => {
-				const { status, message, app = {} } = data;
-				const appId = !!app ? app.id : undefined;
-				if (status === REVIEW_APP_STATUSES.deleted) {
-					throw new pRetry.AbortError(`Review app was deleted: ${message}`);
-				}
 
-				if ((status === REVIEW_APP_STATUSES.errored)) {
-					if (!appId) {
-						throw new pRetry.AbortError(`Review app errored: ${message}`);
-					}
+		const response = await fetch(getReviewAppUrl(reviewApp.id), { headers });
 
-					try {
-						const {
-							output_stream_url
-						} = await getAppBuildWithCommit({ appId, commit });
-						console.error(`App (${appId}, commit: ${commit}) errored.\n\nFor Heroku output see:\n${output_stream_url}`); // eslint-disable-line no-console
-					} catch (e) {
-						console.error(`Could not get app build for app id ${appId}, commit: ${commit}, ${e}`); // eslint-disable-line no-console
-					}
+		await throwIfNotOk(response);
 
-					throw new pRetry.AbortError(`Review app errored: (appId: ${appId}) ${message}`);
-				}
+		const { status, message, app = {} } = await response.json();
 
-				if (status !== REVIEW_APP_STATUSES.created) {
-					const appIdOutput = (status === REVIEW_APP_STATUSES.creating)
-						? `, appId: ${appId}`
-						: '';
-					throw new Error(`Review app not created yet. Current status: ${status}${appIdOutput}`);
-				};
+		const appId = !!app ? app.id : undefined;
 
-				return { reviewAppId, appId };
-			});
-		return result;
+		if (status === REVIEW_APP_STATUSES.deleted) throw new pRetry.AbortError(`Review app was deleted: ${message}`);
+
+		if ((status === REVIEW_APP_STATUSES.errored)) {
+
+			if (!appId) throw new pRetry.AbortError(`Review app errored: ${message}`);
+
+			try {
+
+				const { output_stream_url } = await getAppBuildWithCommit({ appId, commit });
+
+				console.error(`App (${appId}, commit: ${commit}) errored.\n\nFor Heroku output see:\n${output_stream_url}`); // eslint-disable-line no-console
+
+			} catch (error) {
+
+				console.error(`Could not get app build for app id ${appId}, commit: ${commit}, ${error}`); // eslint-disable-line no-console
+
+			}
+
+			throw new pRetry.AbortError(`Review app errored: (appId: ${appId}) ${message}`);
+
+		}
+
+		if (status !== REVIEW_APP_STATUSES.created) {
+
+			const appIdOutput = (status === REVIEW_APP_STATUSES.creating)
+				? `, appId: ${appId}`
+				: '';
+
+			throw new Error(`Review app not created yet. Current status: ${status}${appIdOutput}`);
+
+		}
+
+		return appId;
+
 	};
 
 	return pRetry(checkForCreatedStatus, {
 		factor: RETRY_EXP_BACK_OFF_FACTOR,
 		retries: NUM_RETRIES,
 		minTimeout,
-		onFailedAttempt: (err) => {
-			const { attemptNumber, message } = err;
+		onFailedAttempt: error => {
+			const { attemptNumber, message } = error;
 			console.error(`${attemptNumber}/${NUM_RETRIES}: ${message}`); // eslint-disable-line no-console
 		}
 	});
 };
 
-const getAppName = async ({ appId }) => {
+const getAppName = async appId => {
+
 	const headers = await herokuHeaders();
-	return fetch(getAppUrl(appId), {
-		headers
-	})
-		.then(throwIfNotOk)
-		.then(res => res.json())
-		.then((result) => {
-			const { name } = result;
-			return name;
-		});
+
+	const response = await fetch(getAppUrl(appId), { headers });
+
+	await throwIfNotOk(response);
+
+	const { name } = await response.json();
+
+	return name;
+
 };
 
 const deleteReviewApp = async appId => {
+
 	const headers = await herokuHeaders({ useReviewAppApi: true });
-	const res = await fetch(getReviewAppUrl(appId), { headers, method: 'delete' });
-	return throwIfNotOk(res);
+
+	const response = await fetch(getReviewAppUrl(appId), { headers, method: 'delete' });
+
+	await throwIfNotOk(response);
+
+	return;
+
 };
 
 const findCreatedReviewApp = async ({ pipelineId, branch }) => {
+
 	const headers = await herokuHeaders({ useReviewAppApi: true });
-	return fetch(getPipelineReviewAppsUrl(pipelineId), {
-		headers
-	})
-		.then(throwIfNotOk)
-		.then(res => res.json())
-		.then((reviewApps = []) =>
-			reviewApps.find(({ branch: reviewAppBranch }) => reviewAppBranch === branch));
+
+	const response = await fetch(getPipelineReviewAppsUrl(pipelineId), { headers });
+
+	await throwIfNotOk(response);
+
+	const reviewApps = await response.json() || [];
+
+	return reviewApps.find(({ branch: reviewAppBranch }) => reviewAppBranch === branch);
+
 };
 
-const getBuilds = async (appId) => {
+const getBuilds = async appId => {
+
 	const headers = await herokuHeaders();
-	return fetch(getBuildsUrl(appId), {
-		headers
-	})
-		.then(throwIfNotOk)
-		.then(res => res.json());
+
+	const response = await fetch(getBuildsUrl(appId), { headers });
+
+	await throwIfNotOk(response);
+
+	const data = await response.json();
+
+	return data;
+
 };
 
-const getAppBuildWithCommit = ({ appId, commit }) => {
-	return getBuilds(appId)
-		.then(builds => {
-			const build = builds.find(({ source_blob: { version } }) => version === commit);
+const getAppBuildWithCommit = async ({ appId, commit }) => {
 
-			return build;
-		});
+	const builds = await getBuilds(appId);
+
+	const build = builds.find(({ source_blob: { version } }) => version === commit);
+
+	return build;
+
 };
 
-const waitForReviewAppBuild = ({ commit, minTimeout = MIN_TIMEOUT }) => async ({ reviewAppId, appId }) => {
-	const checkForBuildAppId = () =>
-		getAppBuildWithCommit({ commit, reviewAppId, appId })
-			.then(async build => {
-				if (!build) {
-					try {
-						await deleteReviewApp(reviewAppId);
-					} catch (error) {
-						throw new pRetry.AbortError(`Review app deletion failed. reviewAppId: ${reviewAppId}; commit: ${commit}; ${error}.`);
-					}
+const waitForReviewAppBuild = async ({ commit, reviewAppId, appId, minTimeout = MIN_TIMEOUT }) => {
 
-					throw new pRetry.AbortError(`No review app build found for app id '${appId}'; commit '${commit}'.\nThe presence of a review app without a corresponding build is likely the result of a rebase.\nThe review app has been deleted and a rebuild will now be attempted.`);
-				}
+	const checkForBuildAppId = async () => {
 
-				const { status, output_stream_url } = build;
-				if ((status === BUILD_STATUSES.failed)) {
-					throw new pRetry.AbortError(`Review app build failed, appId: ${appId}, commit: ${commit}.\n\nFor Heroku output see:\n${output_stream_url}`);
-				}
+		const build = await getAppBuildWithCommit({ commit, appId });
 
-				if (status !== BUILD_STATUSES.succeeded) {
-					throw new Error(`Review app build for app id '${appId}' (commit '${commit}') not done yet: ${status}`);
-				}
+		if (!build) {
 
-				return build;
-			})
-			.then(({ app: { id } }) => ({ appId: id }));
+			try {
+
+				await deleteReviewApp(reviewAppId);
+
+			} catch (error) {
+
+				throw new pRetry.AbortError(`Review app deletion failed. reviewAppId: ${reviewAppId}; commit: ${commit}; ${error}.`);
+
+			}
+
+			throw new pRetry.AbortError(`No review app build found for app id '${appId}'; commit '${commit}'.\nThe presence of a review app without a corresponding build is likely the result of a rebase.\nThe review app has been deleted and a rebuild will now be attempted.`);
+
+		}
+
+		const { status, output_stream_url } = build;
+
+		if ((status === BUILD_STATUSES.failed)) throw new pRetry.AbortError(`Review app build failed, appId: ${appId}, commit: ${commit}.\n\nFor Heroku output see:\n${output_stream_url}`);
+
+		if (status !== BUILD_STATUSES.succeeded) throw new Error(`Review app build for app id '${appId}' (commit '${commit}') not done yet: ${status}`);
+
+		return build.app.id;
+
+	};
 
 	return pRetry(checkForBuildAppId, {
 		factor: RETRY_EXP_BACK_OFF_FACTOR,
 		retries: NUM_RETRIES,
 		minTimeout,
-		onFailedAttempt: (err) => {
-			const { attemptNumber, message } = err;
+		onFailedAttempt: error => {
+			const { attemptNumber, message } = error;
 			console.error(`${attemptNumber}/${NUM_RETRIES}: ${message}`); // eslint-disable-line no-console
 		}
 	});
 };
 
 const createReviewApp = async ({ pipelineId, repoName, commit, branch, githubToken }) => {
+
 	const headers = await herokuHeaders({ useReviewAppApi: true });
+
+	const url = await getGithubArchiveRedirectUrl({ repoName, branch, githubToken });
+
 	const body = {
 		pipeline: pipelineId,
 		branch,
 		source_blob: {
-			url: await getGithubArchiveRedirectUrl({ repoName, branch, githubToken }),
+			url,
 			version: commit
 		}
 	};
-	return fetch(REVIEW_APPS_URL, {
-		headers,
-		method: 'post',
-		body: JSON.stringify(body)
-	});
+
+	const response = await fetch(REVIEW_APPS_URL, { headers, method: 'post', body: JSON.stringify(body) });
+
+	return response;
+
 };
 
 /**
@@ -226,58 +265,57 @@ const createReviewApp = async ({ pipelineId, repoName, commit, branch, githubTok
 * @param {string} commit git commit SHA-1 to find the build
 * @param {string} githubToken GitHub token for getting source code
 */
-const getReviewAppName = async ({
-	appName,
-	repoName,
-	branch,
-	commit,
-	githubToken,
-	minTimeout = MIN_TIMEOUT
-}) => {
+const getReviewAppName = async ({ appName, repoName, branch, commit, githubToken, minTimeout = MIN_TIMEOUT }) => {
+
 	const { id: pipelineId } = await pipelineInfo(appName);
 
-	const runReviewAppCreationProcess = () =>
-		createReviewApp({
-			pipelineId,
-			repoName,
-			commit,
-			branch,
-			githubToken
-		})
-		.then(res => {
-			const { status } = res;
-			if (status === 409) {
-				console.error(`Review app already created for '${branch}' branch. Using existing review app for build.`); // eslint-disable-line no-console
-				return findCreatedReviewApp({
-					pipelineId,
-					branch
-				})
-					.then(reviewApp => {
-						if (!reviewApp) {
-							throw new Error(`No review app found for pipeline ${pipelineId}, branch ${branch}`);
-						}
+	const runReviewAppCreationProcess = async () => {
 
-						return reviewApp;
-					})
-					.then(waitTillReviewAppCreated({ commit }))
-					.then(waitForReviewAppBuild({ commit }))
-					.then(getAppName);
-			}
-			return Promise.resolve(res)
-				.then(res => res.json())
-				.then(waitTillReviewAppCreated({ commit }))
-				.then(getAppName);
-		});
+		const response = await createReviewApp({ pipelineId, repoName, commit, branch, githubToken });
+
+		const { status } = response;
+
+		let reviewApp;
+		let appId;
+
+		if (status === CONFLICT_STATUS_CODE) {
+
+			console.error(`Review app already created for '${branch}' branch. Using existing review app for build.`); // eslint-disable-line no-console
+
+			reviewApp = await findCreatedReviewApp({ pipelineId, branch });
+
+			if (!reviewApp) throw new Error(`No review app found for pipeline ${pipelineId}, branch ${branch}`);
+
+			appId = await waitTillReviewAppCreated({ commit, reviewApp });
+
+			appId = await waitForReviewAppBuild({ commit, reviewApp, appId });
+
+			const appName = await getAppName(appId);
+
+			return appName;
+
+		}
+
+		reviewApp = await response.json();
+
+		appId = await waitTillReviewAppCreated({ commit, reviewApp });
+
+		const appName = await getAppName(appId);
+
+		return appName;
+
+	};
 
 	return pRetry(runReviewAppCreationProcess, {
 		factor: RETRY_EXP_BACK_OFF_FACTOR,
 		retries: GET_REVIEW_APP_NAME_NUM_RETRIES,
 		minTimeout,
-		onFailedAttempt: (err) => {
-			const { attemptNumber, message } = err;
+		onFailedAttempt: error => {
+			const { attemptNumber, message } = error;
 			console.error(`${attemptNumber}/${NUM_RETRIES}: ${message}`); // eslint-disable-line no-console
 		}
 	});
+
 };
 
 module.exports = {

--- a/lib/review-apps.js
+++ b/lib/review-apps.js
@@ -10,6 +10,7 @@ const DEFAULT_HEADERS = {
 	'Content-Type': 'application/json'
 };
 
+const GET_REVIEW_APP_NAME_NUM_RETRIES = 1;
 const NUM_RETRIES = 60;
 const RETRY_EXP_BACK_OFF_FACTOR = 1;
 const MIN_TIMEOUT = 10 * 1000;
@@ -56,10 +57,10 @@ const throwIfNotOk = async res => {
 };
 
 const waitTillReviewAppCreated = ({ commit, minTimeout = MIN_TIMEOUT } = {}) => reviewApp => {
-	const { id } = reviewApp;
+	const reviewAppId = reviewApp.id;
 	const checkForCreatedStatus = async () => {
 		const headers = await herokuHeaders({ useReviewAppApi: true });
-		const result = await fetch(getReviewAppUrl(id), {
+		const result = await fetch(getReviewAppUrl(reviewAppId), {
 			headers
 		})
 			.then(throwIfNotOk)
@@ -95,7 +96,7 @@ const waitTillReviewAppCreated = ({ commit, minTimeout = MIN_TIMEOUT } = {}) => 
 					throw new Error(`Review app not created yet. Current status: ${status}${appIdOutput}`);
 				};
 
-				return appId;
+				return { reviewAppId, appId };
 			});
 		return result;
 	};
@@ -111,7 +112,7 @@ const waitTillReviewAppCreated = ({ commit, minTimeout = MIN_TIMEOUT } = {}) => 
 	});
 };
 
-const getAppName = async (appId) => {
+const getAppName = async ({ appId }) => {
 	const headers = await herokuHeaders();
 	return fetch(getAppUrl(appId), {
 		headers
@@ -122,6 +123,12 @@ const getAppName = async (appId) => {
 			const { name } = result;
 			return name;
 		});
+};
+
+const deleteReviewApp = async appId => {
+	const headers = await herokuHeaders({ useReviewAppApi: true });
+	const res = await fetch(getReviewAppUrl(appId), { headers, method: 'delete' });
+	return throwIfNotOk(res);
 };
 
 const findCreatedReviewApp = async ({ pipelineId, branch }) => {
@@ -153,12 +160,18 @@ const getAppBuildWithCommit = ({ appId, commit }) => {
 		});
 };
 
-const waitForReviewAppBuild = ({ commit, minTimeout = MIN_TIMEOUT }) => async (appId) => {
+const waitForReviewAppBuild = ({ commit, minTimeout = MIN_TIMEOUT }) => async ({ reviewAppId, appId }) => {
 	const checkForBuildAppId = () =>
-		getAppBuildWithCommit({ commit, appId })
+		getAppBuildWithCommit({ commit, reviewAppId, appId })
 			.then(async build => {
 				if (!build) {
-					throw new Error(`No review app build found for app id '${appId}';, commit '${commit}'`);
+					try {
+						await deleteReviewApp(reviewAppId);
+					} catch (error) {
+						throw new pRetry.AbortError(`Review app deletion failed. reviewAppId: ${reviewAppId}; commit: ${commit}; ${error}.`);
+					}
+
+					throw new pRetry.AbortError(`No review app build found for app id '${appId}'; commit '${commit}'.\nThe presence of a review app without a corresponding build is likely the result of a rebase.\nThe review app has been deleted and a rebuild will now be attempted.`);
 				}
 
 				const { status, output_stream_url } = build;
@@ -172,7 +185,7 @@ const waitForReviewAppBuild = ({ commit, minTimeout = MIN_TIMEOUT }) => async (a
 
 				return build;
 			})
-			.then(({ app: { id } }) => id);
+			.then(({ app: { id } }) => ({ appId: id }));
 
 	return pRetry(checkForBuildAppId, {
 		factor: RETRY_EXP_BACK_OFF_FACTOR,
@@ -218,17 +231,19 @@ const getReviewAppName = async ({
 	repoName,
 	branch,
 	commit,
-	githubToken
+	githubToken,
+	minTimeout = MIN_TIMEOUT
 }) => {
 	const { id: pipelineId } = await pipelineInfo(appName);
 
-	return createReviewApp({
-		pipelineId,
-		repoName,
-		commit,
-		branch,
-		githubToken
-	})
+	const runReviewAppCreationProcess = () =>
+		createReviewApp({
+			pipelineId,
+			repoName,
+			commit,
+			branch,
+			githubToken
+		})
 		.then(res => {
 			const { status } = res;
 			if (status === 409) {
@@ -253,6 +268,16 @@ const getReviewAppName = async ({
 				.then(waitTillReviewAppCreated({ commit }))
 				.then(getAppName);
 		});
+
+	return pRetry(runReviewAppCreationProcess, {
+		factor: RETRY_EXP_BACK_OFF_FACTOR,
+		retries: GET_REVIEW_APP_NAME_NUM_RETRIES,
+		minTimeout,
+		onFailedAttempt: (err) => {
+			const { attemptNumber, message } = err;
+			console.error(`${attemptNumber}/${NUM_RETRIES}: ${message}`); // eslint-disable-line no-console
+		}
+	});
 };
 
 module.exports = {

--- a/lib/review-apps.js
+++ b/lib/review-apps.js
@@ -67,9 +67,101 @@ const performFetch = async (requestUrl, settings) => {
 
 };
 
-const waitTillReviewAppCreated = async ({ commit, reviewApp, minTimeout = MIN_TIMEOUT } = {}) => {
+const getAppName = async appId => {
 
-	const checkForCreatedStatus = async () => {
+	const headers = await herokuHeaders();
+
+	const response = await performFetch(getAppUrl(appId), { headers });
+
+	const { name } = await response.json();
+
+	return name;
+
+};
+
+const repeatedCheckForBuildSuccessStatus = async ({ commit, appId, minTimeout = MIN_TIMEOUT }) => {
+
+	const checkForBuildSuccessStatus = async () => {
+
+		const { status } = await getAppBuildWithCommit({ commit, appId });
+
+		if (status !== BUILD_STATUSES.succeeded) throw new Error(`Review app build for app id '${appId}' (commit '${commit}') not done yet: ${status}`);
+
+		return;
+
+	};
+
+	return pRetry(checkForBuildSuccessStatus, {
+		factor: RETRY_EXP_BACK_OFF_FACTOR,
+		retries: NUM_RETRIES,
+		minTimeout,
+		onFailedAttempt: error => {
+			const { attemptNumber, message } = error;
+			console.error(`${attemptNumber}/${NUM_RETRIES}: ${message}`); // eslint-disable-line no-console
+		}
+	});
+
+};
+
+const runCheckForBuildSuccessStatus = async ({ commit, appId, minTimeout = MIN_TIMEOUT }) => {
+
+	try {
+
+		await repeatedCheckForBuildSuccessStatus({ commit, appId, minTimeout });
+
+	} catch (error) {
+
+		throw new pRetry.AbortError(error);
+
+	}
+
+	return;
+
+};
+
+const deleteReviewAppAndThrowError = async ({ reviewApp, commit, appId }) => {
+
+	try {
+
+		const headers = await herokuHeaders({ useReviewAppApi: true });
+
+		await performFetch(getReviewAppUrl(reviewApp.id), { headers, method: 'delete' });
+
+	} catch (error) {
+
+		throw new pRetry.AbortError(`Review app deletion failed. reviewAppId: ${reviewApp.id}; commit: ${commit}; ${error}.`);
+
+	}
+
+	throw new Error(`No review app build found for app id '${appId}'; commit '${commit}'.\nThe presence of a review app without a corresponding build is likely the result of a rebase.\nThe review app has been deleted and a rebuild will now be attempted.`);
+
+};
+
+const getBuilds = async appId => {
+
+	const headers = await herokuHeaders();
+
+	const response = await performFetch(getBuildsUrl(appId), { headers });
+
+	const data = await response.json();
+
+	return data;
+
+};
+
+const getAppBuildWithCommit = async ({ appId, commit }) => {
+
+	const builds = await getBuilds(appId);
+
+	const build = builds.find(({ source_blob: { version } }) => version === commit);
+
+	return build;
+
+};
+
+const repeatedCheckForReviewAppCreatedStatus = async ({ commit, reviewApp, minTimeout = MIN_TIMEOUT } = {}) => {
+
+	const checkForReviewAppCreatedStatus = async () => {
 
 		const headers = await herokuHeaders({ useReviewAppApi: true });
 
@@ -115,23 +207,22 @@ const waitTillReviewAppCreated = async ({ commit, reviewApp, minTimeout = MIN_TI
 
 	};
 
-	return pRetry(checkForCreatedStatus, {
+	return pRetry(checkForReviewAppCreatedStatus, {
 		factor: RETRY_EXP_BACK_OFF_FACTOR,
 		retries: NUM_RETRIES,
 		minTimeout,
 		onFailedAttempt: error => {
-
 			const { attemptNumber, message } = error;
 			console.error(`${attemptNumber}/${NUM_RETRIES}: ${message}`); // eslint-disable-line no-console
 		}
 	});
 };
 
-const handleWaitTillReviewAppCreated = async ({ commit, reviewApp, minTimeout = MIN_TIMEOUT }) => {
+const runCheckForReviewAppCreatedStatus = async ({ commit, reviewApp, minTimeout = MIN_TIMEOUT }) => {
 
 	try {
 
-		const appId = await waitTillReviewAppCreated({ commit, reviewApp, minTimeout });
+		const appId = await repeatedCheckForReviewAppCreatedStatus({ commit, reviewApp, minTimeout });
 
 		return appId;
 
@@ -140,36 +231,6 @@ const handleWaitTillReviewAppCreated = async ({ commit, reviewApp, minTimeout = 
 		throw new pRetry.AbortError(error);
 
 	}
-
-};
-
-const getAppName = async appId => {
-
-	const headers = await herokuHeaders();
-
-	const response = await performFetch(getAppUrl(appId), { headers });
-
-	const { name } = await response.json();
-
-	return name;
-
-};
-
-const deleteReviewApp = async ({ reviewApp, commit, appId }) => {
-
-	try {
-
-		const headers = await herokuHeaders({ useReviewAppApi: true });
-
-		await performFetch(getReviewAppUrl(reviewApp.id), { headers, method: 'delete' });
-
-	} catch (error) {
-
-		throw new pRetry.AbortError(`Review app deletion failed. reviewAppId: ${reviewApp.id}; commit: ${commit}; ${error}.`);
-
-	}
-
-	throw new Error(`No review app build found for app id '${appId}'; commit '${commit}'.\nThe presence of a review app without a corresponding build is likely the result of a rebase.\nThe review app has been deleted and a rebuild will now be attempted.`);
 
 };
 
@@ -182,68 +243,6 @@ const findCreatedReviewApp = async ({ pipelineId, branch }) => {
 	const reviewApps = await response.json() || [];
 
 	return reviewApps.find(({ branch: reviewAppBranch }) => reviewAppBranch === branch);
-
-};
-
-const getBuilds = async appId => {
-
-	const headers = await herokuHeaders();
-
-	const response = await performFetch(getBuildsUrl(appId), { headers });
-
-	const data = await response.json();
-
-	return data;
-
-};
-
-const getAppBuildWithCommit = async ({ appId, commit }) => {
-
-	const builds = await getBuilds(appId);
-
-	const build = builds.find(({ source_blob: { version } }) => version === commit);
-
-	return build;
-
-};
-
-const awaitReviewAppBuild = async ({ commit, appId, minTimeout = MIN_TIMEOUT }) => {
-
-	const awaitReviewAppBuildSucceededStatus = async () => {
-
-		const { status } = await getAppBuildWithCommit({ commit, appId });
-
-		if (status !== BUILD_STATUSES.succeeded) throw new Error(`Review app build for app id '${appId}' (commit '${commit}') not done yet: ${status}`);
-
-		return;
-
-	};
-
-	return pRetry(awaitReviewAppBuildSucceededStatus, {
-		factor: RETRY_EXP_BACK_OFF_FACTOR,
-		retries: NUM_RETRIES,
-		minTimeout,
-		onFailedAttempt: error => {
-			const { attemptNumber, message } = error;
-			console.error(`${attemptNumber}/${NUM_RETRIES}: ${message}`); // eslint-disable-line no-console
-		}
-	});
-
-};
-
-const handleNonSucceededReviewAppBuild = async ({ commit, appId, minTimeout = MIN_TIMEOUT }) => {
-
-	try {
-
-		await awaitReviewAppBuild({ commit, appId, minTimeout });
-
-	} catch (error) {
-
-		throw new pRetry.AbortError(error);
-
-	}
-
-	return;
 
 };
 
@@ -300,17 +299,17 @@ const getReviewAppName = async ({ appName, repoName, branch, commit, githubToken
 
 			if (!reviewApp) throw new pRetry.AbortError(`No review app found for pipeline ${pipelineId}, branch ${branch}`);
 
-			appId = await handleWaitTillReviewAppCreated({ commit, reviewApp });
+			appId = await runCheckForReviewAppCreatedStatus({ commit, reviewApp });
 
 			const build = await getAppBuildWithCommit({ commit, appId });
 
-			if (!build) await deleteReviewApp({ reviewApp, commit, appId });
+			if (!build) await deleteReviewAppAndThrowError({ reviewApp, commit, appId });
 
 			const { status, output_stream_url } = build;
 
 			if (status === BUILD_STATUSES.failed) throw new pRetry.AbortError(`Review app build failed, appId: ${appId}, commit: ${commit}.\n\nFor Heroku output see:\n${output_stream_url}`);
 
-			if (status !== BUILD_STATUSES.succeeded) await handleNonSucceededReviewAppBuild({ commit, appId, minTimeout });
+			if (status !== BUILD_STATUSES.succeeded) await runCheckForBuildSuccessStatus({ commit, appId, minTimeout });
 
 			const appName = await getAppName(appId);
 
@@ -320,7 +319,7 @@ const getReviewAppName = async ({ appName, repoName, branch, commit, githubToken
 
 		reviewApp = await response.json();
 
-		appId = await handleWaitTillReviewAppCreated({ commit, reviewApp });
+		appId = await runCheckForReviewAppCreatedStatus({ commit, reviewApp });
 
 		const appName = await getAppName(appId);
 
@@ -341,15 +340,15 @@ const getReviewAppName = async ({ appName, repoName, branch, commit, githubToken
 };
 
 module.exports = {
-	handleNonSucceededReviewAppBuild,
+	getReviewAppName,
 	createReviewApp,
 	findCreatedReviewApp,
-	handleWaitTillReviewAppCreated,
-	getAppName,
-	deleteReviewApp,
-	getBuilds,
+	runCheckForReviewAppCreatedStatus,
+	repeatedCheckForReviewAppCreatedStatus,
 	getAppBuildWithCommit,
-	awaitReviewAppBuild,
-	waitTillReviewAppCreated,
-	getReviewAppName
+	getBuilds,
+	deleteReviewAppAndThrowError,
+	runCheckForBuildSuccessStatus,
+	repeatedCheckForBuildSuccessStatus,
+	getAppName
 };

--- a/lib/review-apps.js
+++ b/lib/review-apps.js
@@ -126,6 +126,24 @@ const waitTillReviewAppCreated = async ({ commit, reviewApp, minTimeout = MIN_TI
 	});
 };
 
+const handleWaitTillReviewAppCreated = async ({ commit, reviewApp }) => {
+
+	let appId;
+
+	try {
+
+		appId = await waitTillReviewAppCreated({ commit, reviewApp });
+
+	} catch (error) {
+
+		throw new pRetry.AbortError(error);
+
+	}
+
+	return appId;
+
+};
+
 const getAppName = async appId => {
 
 	const headers = await herokuHeaders();
@@ -140,15 +158,23 @@ const getAppName = async appId => {
 
 };
 
-const deleteReviewApp = async appId => {
+const deleteReviewApp = async ({ reviewApp, commit, appId }) => {
 
-	const headers = await herokuHeaders({ useReviewAppApi: true });
+	try {
 
-	const response = await fetch(getReviewAppUrl(appId), { headers, method: 'delete' });
+		const headers = await herokuHeaders({ useReviewAppApi: true });
 
-	await throwIfNotOk(response);
+		const response = await fetch(getReviewAppUrl(reviewApp.id), { headers, method: 'delete' });
 
-	return;
+		await throwIfNotOk(response);
+
+	} catch (error) {
+
+		throw new pRetry.AbortError(`Review app deletion failed. reviewAppId: ${reviewApp.id}; commit: ${commit}; ${error}.`);
+
+	}
+
+	throw new Error(`No review app build found for app id '${appId}'; commit '${commit}'.\nThe presence of a review app without a corresponding build is likely the result of a rebase.\nThe review app has been deleted and a rebuild will now be attempted.`);
 
 };
 
@@ -214,6 +240,22 @@ const awaitReviewAppBuild = async ({ commit, appId, minTimeout = MIN_TIMEOUT }) 
 
 };
 
+const handleNonSucceededReviewAppBuild = async ({ commit, appId }) => {
+
+	try {
+
+		await awaitReviewAppBuild({ commit, appId });
+
+	} catch (error) {
+
+		throw new pRetry.AbortError(error);
+
+	}
+
+	return;
+
+};
+
 const createReviewApp = async ({ pipelineId, repoName, commit, branch, githubToken }) => {
 
 	const headers = await herokuHeaders({ useReviewAppApi: true });
@@ -265,54 +307,19 @@ const getReviewAppName = async ({ appName, repoName, branch, commit, githubToken
 
 			reviewApp = await findCreatedReviewApp({ pipelineId, branch });
 
-			if (!reviewApp) throw new Error(`No review app found for pipeline ${pipelineId}, branch ${branch}`);
+			if (!reviewApp) throw new pRetry.AbortError(`No review app found for pipeline ${pipelineId}, branch ${branch}`);
 
-			try {
-
-				appId = await waitTillReviewAppCreated({ commit, reviewApp });
-
-			} catch (error) {
-
-				throw new pRetry.AbortError(error);
-
-			}
+			appId = await handleWaitTillReviewAppCreated({ commit, reviewApp });
 
 			const build = await getAppBuildWithCommit({ commit, appId });
 
-			if (!build) {
+			if (!build) await deleteReviewApp({ reviewApp, commit, appId });
 
-				try {
-
-					await deleteReviewApp(reviewApp.id);
-
-				} catch (error) {
-
-					throw new pRetry.AbortError(`Review app deletion failed. reviewAppId: ${reviewApp.id}; commit: ${commit}; ${error}.`);
-
-				}
-
-				throw new Error(`No review app build found for app id '${appId}'; commit '${commit}'.\nThe presence of a review app without a corresponding build is likely the result of a rebase.\nThe review app has been deleted and a rebuild will now be attempted.`);
-
-			}
-
-			const { status, output_stream_url, app } = build;
+			const { status, output_stream_url } = build;
 
 			if (status === BUILD_STATUSES.failed) throw new pRetry.AbortError(`Review app build failed, appId: ${appId}, commit: ${commit}.\n\nFor Heroku output see:\n${output_stream_url}`);
 
-			if (status !== BUILD_STATUSES.succeeded) {
-
-				try {
-
-					await awaitReviewAppBuild({ commit, appId });
-
-				} catch (error) {
-
-					throw new pRetry.AbortError(error);
-
-				}
-			}
-
-			appId = app.id;
+			if (status !== BUILD_STATUSES.succeeded) await handleNonSucceededReviewAppBuild({ commit, appId });
 
 			const appName = await getAppName(appId);
 
@@ -322,7 +329,7 @@ const getReviewAppName = async ({ appName, repoName, branch, commit, githubToken
 
 		reviewApp = await response.json();
 
-		appId = await waitTillReviewAppCreated({ commit, reviewApp });
+		appId = await handleWaitTillReviewAppCreated({ commit, reviewApp });
 
 		const appName = await getAppName(appId);
 

--- a/lib/review-apps.js
+++ b/lib/review-apps.js
@@ -190,39 +190,19 @@ const getAppBuildWithCommit = async ({ appId, commit }) => {
 
 };
 
-const waitForReviewAppBuild = async ({ commit, reviewAppId, appId, minTimeout = MIN_TIMEOUT }) => {
+const awaitReviewAppBuild = async ({ commit, appId, minTimeout = MIN_TIMEOUT }) => {
 
-	const checkForBuildAppId = async () => {
+	const awaitReviewAppBuildSucceededStatus = async () => {
 
-		const build = await getAppBuildWithCommit({ commit, appId });
-
-		if (!build) {
-
-			try {
-
-				await deleteReviewApp(reviewAppId);
-
-			} catch (error) {
-
-				throw new pRetry.AbortError(`Review app deletion failed. reviewAppId: ${reviewAppId}; commit: ${commit}; ${error}.`);
-
-			}
-
-			throw new pRetry.AbortError(`No review app build found for app id '${appId}'; commit '${commit}'.\nThe presence of a review app without a corresponding build is likely the result of a rebase.\nThe review app has been deleted and a rebuild will now be attempted.`);
-
-		}
-
-		const { status, output_stream_url } = build;
-
-		if ((status === BUILD_STATUSES.failed)) throw new pRetry.AbortError(`Review app build failed, appId: ${appId}, commit: ${commit}.\n\nFor Heroku output see:\n${output_stream_url}`);
+		const { status } = await getAppBuildWithCommit({ commit, appId });
 
 		if (status !== BUILD_STATUSES.succeeded) throw new Error(`Review app build for app id '${appId}' (commit '${commit}') not done yet: ${status}`);
 
-		return build.app.id;
+		return;
 
 	};
 
-	return pRetry(checkForBuildAppId, {
+	return pRetry(awaitReviewAppBuildSucceededStatus, {
 		factor: RETRY_EXP_BACK_OFF_FACTOR,
 		retries: NUM_RETRIES,
 		minTimeout,
@@ -231,6 +211,7 @@ const waitForReviewAppBuild = async ({ commit, reviewAppId, appId, minTimeout = 
 			console.error(`${attemptNumber}/${NUM_RETRIES}: ${message}`); // eslint-disable-line no-console
 		}
 	});
+
 };
 
 const createReviewApp = async ({ pipelineId, repoName, commit, branch, githubToken }) => {
@@ -286,9 +267,52 @@ const getReviewAppName = async ({ appName, repoName, branch, commit, githubToken
 
 			if (!reviewApp) throw new Error(`No review app found for pipeline ${pipelineId}, branch ${branch}`);
 
-			appId = await waitTillReviewAppCreated({ commit, reviewApp });
+			try {
 
-			appId = await waitForReviewAppBuild({ commit, reviewApp, appId });
+				appId = await waitTillReviewAppCreated({ commit, reviewApp });
+
+			} catch (error) {
+
+				throw new pRetry.AbortError(error);
+
+			}
+
+			const build = await getAppBuildWithCommit({ commit, appId });
+
+			if (!build) {
+
+				try {
+
+					await deleteReviewApp(reviewApp.id);
+
+				} catch (error) {
+
+					throw new pRetry.AbortError(`Review app deletion failed. reviewAppId: ${reviewApp.id}; commit: ${commit}; ${error}.`);
+
+				}
+
+				throw new Error(`No review app build found for app id '${appId}'; commit '${commit}'.\nThe presence of a review app without a corresponding build is likely the result of a rebase.\nThe review app has been deleted and a rebuild will now be attempted.`);
+
+			}
+
+			const { status, output_stream_url, app } = build;
+
+			if (status === BUILD_STATUSES.failed) throw new pRetry.AbortError(`Review app build failed, appId: ${appId}, commit: ${commit}.\n\nFor Heroku output see:\n${output_stream_url}`);
+
+			if (status !== BUILD_STATUSES.succeeded) {
+
+				try {
+
+					await awaitReviewAppBuild({ commit, appId });
+
+				} catch (error) {
+
+					throw new pRetry.AbortError(error);
+
+				}
+			}
+
+			appId = app.id;
 
 			const appName = await getAppName(appId);
 
@@ -324,7 +348,7 @@ module.exports = {
 	getAppName,
 	getBuilds,
 	getAppBuildWithCommit,
-	waitForReviewAppBuild,
+	awaitReviewAppBuild,
 	waitTillReviewAppCreated,
 	getReviewAppName
 };

--- a/lib/review-apps.js
+++ b/lib/review-apps.js
@@ -47,7 +47,9 @@ const herokuHeaders = async ({ useReviewAppApi } = {}) => {
 
 };
 
-const throwIfNotOk = async response => {
+const performFetch = async (requestUrl, settings) => {
+
+	const response = await fetch(requestUrl, settings);
 
 	const { ok, status, url } = response;
 
@@ -71,9 +73,7 @@ const waitTillReviewAppCreated = async ({ commit, reviewApp, minTimeout = MIN_TI
 
 		const headers = await herokuHeaders({ useReviewAppApi: true });
 
-		const response = await fetch(getReviewAppUrl(reviewApp.id), { headers });
-
-		await throwIfNotOk(response);
+		const response = await performFetch(getReviewAppUrl(reviewApp.id), { headers });
 
 		const { status, message, app = {} } = await response.json();
 
@@ -147,9 +147,7 @@ const getAppName = async appId => {
 
 	const headers = await herokuHeaders();
 
-	const response = await fetch(getAppUrl(appId), { headers });
-
-	await throwIfNotOk(response);
+	const response = await performFetch(getAppUrl(appId), { headers });
 
 	const { name } = await response.json();
 
@@ -163,9 +161,7 @@ const deleteReviewApp = async ({ reviewApp, commit, appId }) => {
 
 		const headers = await herokuHeaders({ useReviewAppApi: true });
 
-		const response = await fetch(getReviewAppUrl(reviewApp.id), { headers, method: 'delete' });
-
-		await throwIfNotOk(response);
+		await performFetch(getReviewAppUrl(reviewApp.id), { headers, method: 'delete' });
 
 	} catch (error) {
 
@@ -181,9 +177,7 @@ const findCreatedReviewApp = async ({ pipelineId, branch }) => {
 
 	const headers = await herokuHeaders({ useReviewAppApi: true });
 
-	const response = await fetch(getPipelineReviewAppsUrl(pipelineId), { headers });
-
-	await throwIfNotOk(response);
+	const response = await performFetch(getPipelineReviewAppsUrl(pipelineId), { headers });
 
 	const reviewApps = await response.json() || [];
 
@@ -195,9 +189,7 @@ const getBuilds = async appId => {
 
 	const headers = await herokuHeaders();
 
-	const response = await fetch(getBuildsUrl(appId), { headers });
-
-	await throwIfNotOk(response);
+	const response = await performFetch(getBuildsUrl(appId), { headers });
 
 	const data = await response.json();
 

--- a/lib/review-apps.unit.test.js
+++ b/lib/review-apps.unit.test.js
@@ -2,33 +2,45 @@ require('isomorphic-fetch');
 const nock = require('nock');
 const pRetry = require('p-retry');
 
-jest.mock('./github-api');
 const reviewApps = require('./review-apps');
+
 const BASE_HEROKU_API_URL = 'https://api.heroku.com';
 
+jest.mock('./github-api');
+
 describe('review-apps', () => {
+
 	let nockScope;
 	let reviewAppsNockScope;
+
 	beforeAll(() => {
+
 		nockScope = nock(BASE_HEROKU_API_URL)
 			.matchHeader('accept', 'application/vnd.heroku+json; version=3');
+
 		reviewAppsNockScope = nock(BASE_HEROKU_API_URL)
 			.matchHeader('accept', 'application/vnd.heroku+json; version=3.review-apps');
+
 		jest.mock('shellpromise', () => a => a, { virtual: true });
 
 		// WARNING: Disable error logs, to clean up test output
 		// Re-enable here if need be
 		jest.spyOn(console, 'error').mockImplementation().mockName('console.error');
+
 	});
 
 	afterAll(() => {
+
 		jest.unmock('shellpromise');
 		jest.unmock('./github-api');
+
 	});
 
 	afterEach(() => {
+
 		nock.cleanAll();
 		jest.resetAllMocks();
+
 	});
 
 	describe('handleNonSucceededReviewAppBuild', () => {
@@ -88,9 +100,11 @@ describe('review-apps', () => {
 	});
 
 	describe('createReviewApp', () => {
+
 		const { createReviewApp } = reviewApps;
 
 		it('returns created review app', async () => {
+
 			const pipelineId = 'pipeline123';
 			const branch = 'some-branch';
 			const repoName = 'next-amazing';
@@ -100,13 +114,7 @@ describe('review-apps', () => {
 			reviewAppsNockScope.post('/review-apps')
 				.reply(200, {});
 
-			return createReviewApp({
-				pipelineId,
-				branch,
-				repoName,
-				commit,
-				githubToken
-			})
+			return createReviewApp({ pipelineId, branch, repoName, commit, githubToken })
 				.then(async res => {
 					const { ok } = res;
 					expect(ok).toBeTruthy();
@@ -114,9 +122,11 @@ describe('review-apps', () => {
 					const reviewApp = await res.json();
 					expect(reviewApp).toBeTruthy();
 				});
+
 		});
 
 		it('returns an error', async () => {
+
 			const pipelineId = 'pipeline123';
 			const branch = 'some-branch';
 			const repoName = 'next-amazing';
@@ -126,13 +136,7 @@ describe('review-apps', () => {
 			reviewAppsNockScope.post('/review-apps')
 				.reply(400, {});
 
-			return createReviewApp({
-				pipelineId,
-				branch,
-				repoName,
-				commit,
-				githubToken
-			})
+			return createReviewApp({ pipelineId, branch, repoName, commit, githubToken })
 				.then(async res => {
 					const { ok } = res;
 					expect(ok).toBeFalsy();
@@ -140,57 +144,61 @@ describe('review-apps', () => {
 					const error = await res.json();
 					expect(error).toBeTruthy();
 				});
+
 		});
+
 	});
 
 	describe('findCreatedReviewApp', () => {
+
 		const { findCreatedReviewApp } = reviewApps;
 
 		it('returns review app of branch', async () => {
 			const pipelineId = 'pipeline123';
 			const branch = 'some-branch';
+
 			reviewAppsNockScope.get('/pipelines/pipeline123/review-apps')
 				.reply(200, [
 					{
 						branch
 					}
 				]);
-			const reviewApp = await findCreatedReviewApp({
-				pipelineId,
-				branch
-			});
-			expect(reviewApp).toEqual({
-				branch
-			});
+
+			const reviewApp = await findCreatedReviewApp({ pipelineId, branch });
+			expect(reviewApp).toEqual({ branch });
+
 		});
 
 		it('returns undefined if branch review app is not found', async () => {
+
 			const pipelineId = 'pipeline123';
 			const branch = 'some-branch';
+
 			reviewAppsNockScope.get('/pipelines/pipeline123/review-apps')
 				.reply(200, []);
-			const reviewApp = await findCreatedReviewApp({
-				pipelineId,
-				branch
-			});
+
+			const reviewApp = await findCreatedReviewApp({ pipelineId, branch });
 			expect(reviewApp).toBeUndefined();
+
 		});
 
 		it('throws an error', async () => {
+
 			const pipelineId = 'pipeline123';
+
 			reviewAppsNockScope.get('/pipelines/pipeline123/review-apps')
 				.reply(400, {
 					message: 'Some error occurred'
 				});
 
 			try {
-				await findCreatedReviewApp({
-					pipelineId
-				});
+				await findCreatedReviewApp({ pipelineId });
 			} catch (error) {
 				expect(error.message).toEqual('Some error occurred');
 			}
+
 		});
+
 	});
 
 	describe('handleWaitTillReviewAppCreated', () => {
@@ -202,9 +210,7 @@ describe('review-apps', () => {
 			const appId = 'app123';
 			const commit = 'ababa';
 			const reviewAppId = 'reviewApp123';
-			const reviewApp = {
-				id: reviewAppId
-			};
+			const reviewApp = { id: reviewAppId };
 
 			reviewAppsNockScope.get('/review-apps/reviewApp123')
 				.reply(200, {
@@ -223,9 +229,7 @@ describe('review-apps', () => {
 
 			const commit = 'ababa';
 			const reviewAppId = 'reviewApp123';
-			const reviewApp = {
-				id: reviewAppId
-			};
+			const reviewApp = { id: reviewAppId };
 
 			reviewAppsNockScope.get('/review-apps/reviewApp123')
 				.times(60)
@@ -245,20 +249,27 @@ describe('review-apps', () => {
 	});
 
 	describe('getAppName', () => {
+
 		const { getAppName } = reviewApps;
 
 		it('returns name', async () => {
+
 			const appId = 'app123';
+
 			nockScope.get('/apps/app123')
 				.reply(200, {
 					name: 'the-app'
 				});
+
 			const name = await getAppName(appId);
 			expect(name).toEqual('the-app');
+
 		});
 
 		it('throws an error', async () => {
+
 			const appId = 'app123';
+
 			nockScope.get('/apps/app123')
 				.reply(400, {
 					message: 'Some error occurred'
@@ -269,7 +280,9 @@ describe('review-apps', () => {
 			} catch (error) {
 				expect(error.message).toEqual('Some error occurred');
 			}
+
 		});
+
 	});
 
 	describe('deleteReviewApp', () => {
@@ -279,9 +292,7 @@ describe('review-apps', () => {
 		it('throws error (to trigger retry of calling function) after successful deletion of review app', async () => {
 
 			const reviewAppId = 'reviewApp123';
-			const reviewApp = {
-				id: reviewAppId
-			};
+			const reviewApp = { id: reviewAppId };
 			const commit = 'ababa';
 			const appId = 'app123';
 
@@ -303,9 +314,7 @@ describe('review-apps', () => {
 		it('throws pRetry.AbortError if an error when deleting the review app errors', async () => {
 
 			const reviewAppId = 'reviewApp123';
-			const reviewApp = {
-				id: reviewAppId
-			};
+			const reviewApp = { id: reviewAppId };
 			const commit = 'ababa';
 			const appId = 'app123';
 
@@ -327,17 +336,25 @@ describe('review-apps', () => {
 	});
 
 	describe('getBuilds', () => {
+
 		const { getBuilds } = reviewApps;
+
 		it('returns builds', async () => {
+
 			const appId = 'app123';
+
 			nockScope.get('/apps/app123/builds')
 				.reply(200, []);
+
 			const builds = await getBuilds(appId);
 			expect(builds).toBeTruthy();
+
 		});
 
 		it('throws an error', async () => {
+
 			const appId = 'app123';
+
 			nockScope.get('/apps/app123/builds')
 				.reply(400, {
 					message: 'Some error occurred'
@@ -348,14 +365,20 @@ describe('review-apps', () => {
 			} catch (error) {
 				expect(error.message).toEqual('Some error occurred');
 			}
+
 		});
+
 	});
 
 	describe('getAppBuildWithCommit', () => {
+
 		const { getAppBuildWithCommit } = reviewApps;
+
 		it('returns build', async () => {
+
 			const appId = 'app123';
 			const commit = 'ababa';
+
 			nockScope.get('/apps/app123/builds')
 				.reply(200, [
 					{
@@ -364,13 +387,17 @@ describe('review-apps', () => {
 						}
 					}
 				]);
+
 			const build = await getAppBuildWithCommit({ appId, commit });
 			expect(build).toBeTruthy();
+
 		});
 
 		it('returns undefined if there is no build with the commit', async () => {
+
 			const appId = 'app123';
 			const commit = 'ababa';
+
 			nockScope.get('/apps/app123/builds')
 				.reply(200, [
 					{
@@ -379,18 +406,25 @@ describe('review-apps', () => {
 						}
 					}
 				]);
+
 			const build = await getAppBuildWithCommit({ appId, commit });
 			expect(build).toBeFalsy();
+
 		});
 
 		it('returns undefined if there is no builds', async () => {
+
 			const appId = 'app123';
 			const commit = 'ababa';
+
 			nockScope.get('/apps/app123/builds')
 				.reply(200, []);
+
 			const build = await getAppBuildWithCommit({ appId, commit });
 			expect(build).toBeFalsy();
+
 		});
+
 	});
 
 	describe('awaitReviewAppBuild', () => {
@@ -468,14 +502,15 @@ describe('review-apps', () => {
 	});
 
 	describe('waitTillReviewAppCreated', () => {
+
 		const { waitTillReviewAppCreated } = reviewApps;
 
 		it('returns review app id', async () => {
+
 			const appId = 'app123';
 			const reviewAppId = 'reviewApp123';
-			const reviewApp = {
-				id: reviewAppId
-			};
+			const reviewApp = { id: reviewAppId };
+
 			reviewAppsNockScope.get('/review-apps/reviewApp123')
 				.reply(200, {
 					app: {
@@ -487,14 +522,15 @@ describe('review-apps', () => {
 			const waitedReviewAppBuild = await waitTillReviewAppCreated({ reviewApp });
 
 			expect(waitedReviewAppBuild).toEqual(appId);
+
 		});
 
 		it('waits for review app id until created', async () => {
+
 			const appId = 'app123';
 			const reviewAppId = 'reviewApp123';
-			const reviewApp = {
-				id: reviewAppId
-			};
+			const reviewApp = { id: reviewAppId };
+
 			reviewAppsNockScope
 				.get('/review-apps/reviewApp123')
 				.reply(200, {
@@ -511,20 +547,17 @@ describe('review-apps', () => {
 					status: 'created'
 				});
 
-			const waitedReviewAppBuild = await waitTillReviewAppCreated({
-				reviewApp,
-				minTimeout: 0
-			});
-
+			const waitedReviewAppBuild = await waitTillReviewAppCreated({ reviewApp, minTimeout: 0 });
 			expect(waitedReviewAppBuild).toEqual(appId);
+
 		});
 
 		it('waits for review app id even if there is a http error', async () => {
+
 			const appId = 'app123';
 			const reviewAppId = 'reviewApp123';
-			const reviewApp = {
-				id: reviewAppId
-			};
+			const reviewApp = { id: reviewAppId };
+
 			reviewAppsNockScope
 				.get('/review-apps/reviewApp123')
 				.reply(400, {})
@@ -536,19 +569,16 @@ describe('review-apps', () => {
 					status: 'created'
 				});
 
-			const waitedReviewAppBuild = await waitTillReviewAppCreated({
-				reviewApp,
-				minTimeout: 0
-			});
-
+			const waitedReviewAppBuild = await waitTillReviewAppCreated({ reviewApp, minTimeout: 0 });
 			expect(waitedReviewAppBuild).toEqual(appId);
+
 		});
 
 		it('throws error if review app status is deleted', async () => {
+
 			const reviewAppId = 'reviewApp123';
-			const reviewApp = {
-				id: reviewAppId
-			};
+			const reviewApp = { id: reviewAppId };
+
 			reviewAppsNockScope.get('/review-apps/reviewApp123')
 				.reply(200, {
 					status: 'deleted'
@@ -559,13 +589,14 @@ describe('review-apps', () => {
 					const { message } = error;
 					expect(message).toMatch('Review app was deleted');
 				});
+
 		});
 
 		it('throws error if review app status is errored', async () => {
+
 			const reviewAppId = 'reviewApp123';
-			const reviewApp = {
-				id: reviewAppId
-			};
+			const reviewApp = { id: reviewAppId };
+
 			reviewAppsNockScope.get('/review-apps/reviewApp123')
 				.reply(200, {
 					status: 'errored'
@@ -576,13 +607,14 @@ describe('review-apps', () => {
 					const { message } = error;
 					expect(message).toMatch('Review app errored');
 				});
+
 		});
 
 		it('can error if app is null', async () => {
+
 			const reviewAppId = 'reviewApp123';
-			const reviewApp = {
-				id: reviewAppId
-			};
+			const reviewApp = { id: reviewAppId };
+
 			reviewAppsNockScope.get('/review-apps/reviewApp123')
 				.reply(200, {
 					app: null,
@@ -594,15 +626,16 @@ describe('review-apps', () => {
 					const { message } = error;
 					expect(message).toMatch('Review app errored');
 				});
+
 		});
 
 		it('logs output stream url if review app status is errored', async () => {
+
 			const appId = 'app123';
 			const reviewAppId = 'reviewApp123';
-			const reviewApp = {
-				id: reviewAppId
-			};
+			const reviewApp = { id: reviewAppId };
 			const commit = 'ababab';
+
 			reviewAppsNockScope.get('/review-apps/reviewApp123')
 				.reply(200, {
 					app: {
@@ -610,6 +643,7 @@ describe('review-apps', () => {
 					},
 					status: 'errored'
 				});
+
 			nockScope.get('/apps/app123/builds')
 				.reply(200, [
 					{
@@ -627,9 +661,11 @@ describe('review-apps', () => {
 				.catch(() => {
 					expect(console.error.mock.calls[0][0]).toMatch('https://heroku.com/builds/output/app123'); // eslint-disable-line no-console
 				});
+
 		});
 
 		it('logs error if review app status is errored and build endpoint errors', async () => {
+
 			const appId = 'app123';
 			const reviewAppId = 'reviewApp123';
 			const reviewApp = {
@@ -639,8 +675,10 @@ describe('review-apps', () => {
 				id: reviewAppId,
 				status: 'errored'
 			};
+
 			reviewAppsNockScope.get('/review-apps/reviewApp123')
 				.reply(200, reviewApp);
+
 			nockScope.get('/apps/app123/builds')
 				.reply(400);
 
@@ -648,13 +686,14 @@ describe('review-apps', () => {
 				.catch(() => {
 					expect(console.error.mock.calls[0][0]).toMatch('Could not get app build'); // eslint-disable-line no-console
 				});
+
 		});
 
 		it('times out', async () => {
+
 			const reviewAppId = 'reviewApp123';
-			const reviewApp = {
-				id: reviewAppId
-			};
+			const reviewApp = { id: reviewAppId };
+
 			reviewAppsNockScope
 				.get('/review-apps/reviewApp123')
 				.times(60)
@@ -666,6 +705,7 @@ describe('review-apps', () => {
 					expect(message).toMatch('Review app not created yet');
 				});
 		});
+
 	});
 
 	describe('getReviewAppName', () => {
@@ -746,14 +786,7 @@ describe('review-apps', () => {
 					});
 
 				try {
-					await getReviewAppName({
-						appName,
-						repoName,
-						branch,
-						commit,
-						githubToken,
-						minTimeout: 0
-					});
+					await getReviewAppName({ appName, repoName, branch, commit, githubToken, minTimeout: 0 });
 				} catch ({ message }) {
 					expect(message).toMatch('Review app was deleted');
 				}
@@ -798,14 +831,7 @@ describe('review-apps', () => {
 					});
 
 				try {
-					await getReviewAppName({
-						appName,
-						repoName,
-						branch,
-						commit,
-						githubToken,
-						minTimeout: 0
-					});
+					await getReviewAppName({ appName, repoName, branch, commit, githubToken, minTimeout: 0 });
 				} catch ({ message }) {
 					expect(message).toMatch('Review app errored');
 					expect(message).toMatch(appId);
@@ -876,15 +902,7 @@ describe('review-apps', () => {
 						status: 'created'
 					});
 
-				const name = await getReviewAppName({
-					appName,
-					repoName,
-					branch,
-					commit,
-					githubToken,
-					minTimeout: 0
-				});
-
+				const name = await getReviewAppName({ appName, repoName, branch, commit, githubToken, minTimeout: 0 });
 				expect(name).toEqual(appName);
 
 			});
@@ -944,14 +962,7 @@ describe('review-apps', () => {
 						}
 					});
 
-				const name = await getReviewAppName({
-					appName,
-					repoName,
-					branch,
-					commit,
-					githubToken
-				});
-
+				const name = await getReviewAppName({ appName, repoName, branch, commit, githubToken });
 				expect(name).toEqual(appName);
 
 			});
@@ -1081,15 +1092,7 @@ describe('review-apps', () => {
 						}
 					});
 
-				const name = await getReviewAppName({
-					appName,
-					repoName,
-					branch,
-					commit,
-					githubToken,
-					minTimeout: 0
-				});
-
+				const name = await getReviewAppName({ appName, repoName, branch, commit, githubToken, minTimeout: 0 });
 				expect(name).toEqual(appName);
 
 			});
@@ -1194,14 +1197,7 @@ describe('review-apps', () => {
 						}
 					});
 
-				const name = await getReviewAppName({
-					appName,
-					repoName,
-					branch,
-					commit,
-					githubToken
-				});
-
+				const name = await getReviewAppName({ appName, repoName, branch, commit, githubToken });
 				expect(name).toEqual(appName);
 
 			});

--- a/lib/review-apps.unit.test.js
+++ b/lib/review-apps.unit.test.js
@@ -461,13 +461,9 @@ describe('review-apps', () => {
 			nockScope.get('/apps/app123/builds')
 				.reply(200, [reviewAppBuild]);
 
-			try {
-				await repeatedCheckForBuildSuccessStatus({ commit, appId });
-			} catch (error) {
-				expect(true).toBeFalsy();
-			}
+			const returnValue = await repeatedCheckForBuildSuccessStatus({ commit, appId });
 
-			expect(true).toBeTruthy();
+			expect(returnValue).toBeUndefined();
 
 		});
 

--- a/lib/review-apps.unit.test.js
+++ b/lib/review-apps.unit.test.js
@@ -66,13 +66,9 @@ describe('review-apps', () => {
 					}
 				]);
 
-			try {
-				await runCheckForBuildSuccessStatus({ commit, appId, minTimeout: 0 });
-			} catch (error) {
-				expect(true).toBeFalsy();
-			}
+			const returnValue = await runCheckForBuildSuccessStatus({ commit, appId });
 
-			expect(true).toBeTruthy();
+			expect(returnValue).toBeUndefined();
 
 		});
 

--- a/lib/review-apps.unit.test.js
+++ b/lib/review-apps.unit.test.js
@@ -231,7 +231,7 @@ describe('review-apps', () => {
 		});
 	});
 
-	describe('waitForReviewAppBuild', () => {
+	describe.skip('waitForReviewAppBuild', () => {
 		const { waitForReviewAppBuild } = reviewApps;
 
 		it('returns appId of succeeded review app build', async () => {
@@ -674,7 +674,7 @@ describe('review-apps', () => {
 			expect(name).toEqual(appName);
 		});
 
-		it('throws an error if review app is deleted on two subsequent attempts', async () => {
+		it('throws an error if review app is deleted', async () => {
 			const appName = 'next-app';
 			const repoName = 'next-app-repo';
 			const branch = 'new-idea-branch';
@@ -686,19 +686,16 @@ describe('review-apps', () => {
 			const appId = 'app123';
 
 			nockScope.get('/pipelines/next-app')
-				.times(2)
 				.reply(200, {
 					id: pipelineId
 				});
 			reviewAppsNockScope
 				.post('/review-apps')
-				.times(2)
 				.reply(409, {
 					id: 'conflict',
 					message: 'A review app already exists for the post-build branch'
 				})
 				.get('/pipelines/pipelineId/review-apps')
-				.times(2)
 				.reply(200, [
 					{
 						id: reviewAppId,
@@ -706,7 +703,6 @@ describe('review-apps', () => {
 					}
 				])
 				.get('/review-apps/reviewAppId')
-				.times(2)
 				.reply(200, {
 					status: 'deleted',
 					app: {
@@ -728,7 +724,7 @@ describe('review-apps', () => {
 			}
 		});
 
-		it('throws an error if review app errors on two subsequent attempts', async () => {
+		it('throws an error if review app errors', async () => {
 			const appName = 'next-app';
 			const repoName = 'next-app-repo';
 			const branch = 'new-idea-branch';
@@ -745,13 +741,11 @@ describe('review-apps', () => {
 				});
 			reviewAppsNockScope
 				.post('/review-apps')
-				.times(2)
 				.reply(409, {
 					id: 'conflict',
 					message: 'A review app already exists for the post-build branch'
 				})
 				.get('/pipelines/pipelineId/review-apps')
-				.times(2)
 				.reply(200, [
 					{
 						id: reviewAppId,
@@ -759,7 +753,6 @@ describe('review-apps', () => {
 					}
 				])
 				.get('/review-apps/reviewAppId')
-				.times(2)
 				.reply(200, {
 					status: 'errored',
 					app: {

--- a/lib/review-apps.unit.test.js
+++ b/lib/review-apps.unit.test.js
@@ -43,9 +43,9 @@ describe('review-apps', () => {
 
 	});
 
-	describe('handleNonSucceededReviewAppBuild', () => {
+	describe('runCheckForBuildSuccessStatus', () => {
 
-		const { handleNonSucceededReviewAppBuild } = reviewApps;
+		const { runCheckForBuildSuccessStatus } = reviewApps;
 
 		it('returns without throwing an error if awaiting the review app build does not error', async () => {
 
@@ -67,7 +67,7 @@ describe('review-apps', () => {
 				]);
 
 			try {
-				await handleNonSucceededReviewAppBuild({ commit, appId, minTimeout: 0 });
+				await runCheckForBuildSuccessStatus({ commit, appId, minTimeout: 0 });
 			} catch (error) {
 				expect(true).toBeFalsy();
 			}
@@ -89,7 +89,7 @@ describe('review-apps', () => {
 				});
 
 			try {
-				await handleNonSucceededReviewAppBuild({ commit, appId, minTimeout: 0 });
+				await runCheckForBuildSuccessStatus({ commit, appId, minTimeout: 0 });
 			} catch (error) {
 				expect(error.message).toMatch('Some error occurred');
 				expect(error).toBeInstanceOf(pRetry.AbortError);
@@ -201,9 +201,9 @@ describe('review-apps', () => {
 
 	});
 
-	describe('handleWaitTillReviewAppCreated', () => {
+	describe('runCheckForReviewAppCreatedStatus', () => {
 
-		const { handleWaitTillReviewAppCreated } = reviewApps;
+		const { runCheckForReviewAppCreatedStatus } = reviewApps;
 
 		it('returns appId', async () => {
 
@@ -220,7 +220,7 @@ describe('review-apps', () => {
 					status: 'created'
 				});
 
-			const returnedAppId = await handleWaitTillReviewAppCreated({ commit, reviewApp });
+			const returnedAppId = await runCheckForReviewAppCreatedStatus({ commit, reviewApp });
 			expect(returnedAppId).toEqual(appId);
 
 		});
@@ -238,7 +238,7 @@ describe('review-apps', () => {
 				});
 
 			try {
-				await handleWaitTillReviewAppCreated({ commit, reviewApp, minTimeout: 0 });
+				await runCheckForReviewAppCreatedStatus({ commit, reviewApp, minTimeout: 0 });
 			} catch (error) {
 				expect(error.message).toMatch('Some error occurred');
 				expect(error).toBeInstanceOf(pRetry.AbortError);
@@ -285,9 +285,9 @@ describe('review-apps', () => {
 
 	});
 
-	describe('deleteReviewApp', () => {
+	describe('deleteReviewAppAndThrowError', () => {
 
-		const { deleteReviewApp } = reviewApps;
+		const { deleteReviewAppAndThrowError } = reviewApps;
 
 		it('throws error (to trigger retry of calling function) after successful deletion of review app', async () => {
 
@@ -301,7 +301,7 @@ describe('review-apps', () => {
 				.reply(200);
 
 			try {
-				await deleteReviewApp({ reviewApp, commit, appId });
+				await deleteReviewAppAndThrowError({ reviewApp, commit, appId });
 			} catch (error) {
 				expect(error.message).toMatch('No review app build found for app id \'app123\'; commit \'ababa\'');
 				expect(error.message).toMatch('The presence of a review app without a corresponding build is likely the result of a rebase.');
@@ -325,7 +325,7 @@ describe('review-apps', () => {
 				});
 
 			try {
-				await deleteReviewApp({ reviewApp, commit, appId });
+				await deleteReviewAppAndThrowError({ reviewApp, commit, appId });
 			} catch (error) {
 				expect(error.message).toMatch('Some error occurred');
 				expect(error).toBeInstanceOf(pRetry.AbortError);
@@ -427,9 +427,9 @@ describe('review-apps', () => {
 
 	});
 
-	describe('awaitReviewAppBuild', () => {
+	describe('repeatedCheckForBuildSuccessStatus', () => {
 
-		const { awaitReviewAppBuild } = reviewApps;
+		const { repeatedCheckForBuildSuccessStatus } = reviewApps;
 
 		it('returns without throwing an error if the app build is returned with a status of \'succeeded\'', async () => {
 
@@ -446,7 +446,7 @@ describe('review-apps', () => {
 				.reply(200, [reviewAppBuild]);
 
 			try {
-				await awaitReviewAppBuild({ commit, appId });
+				await repeatedCheckForBuildSuccessStatus({ commit, appId });
 			} catch (error) {
 				expect(true).toBeFalsy();
 			}
@@ -467,7 +467,7 @@ describe('review-apps', () => {
 				});
 
 			try {
-				await awaitReviewAppBuild({ commit, appId, minTimeout: 0 });
+				await repeatedCheckForBuildSuccessStatus({ commit, appId, minTimeout: 0 });
 			} catch (error) {
 				expect(error.message).toMatch('Some error occurred');
 				expect(error).toBeInstanceOf(Error);
@@ -491,7 +491,7 @@ describe('review-apps', () => {
 				.reply(200, [reviewAppBuild]);
 
 			try {
-				await awaitReviewAppBuild({ commit, appId, minTimeout: 0 });
+				await repeatedCheckForBuildSuccessStatus({ commit, appId, minTimeout: 0 });
 			} catch (error) {
 				expect(error.message).toMatch('Review app build for app id \'app123\' (commit \'a00000000000\') not done yet: pending');
 				expect(error).toBeInstanceOf(Error);
@@ -501,9 +501,9 @@ describe('review-apps', () => {
 
 	});
 
-	describe('waitTillReviewAppCreated', () => {
+	describe('repeatedCheckForReviewAppCreatedStatus', () => {
 
-		const { waitTillReviewAppCreated } = reviewApps;
+		const { repeatedCheckForReviewAppCreatedStatus } = reviewApps;
 
 		it('returns review app id', async () => {
 
@@ -519,7 +519,7 @@ describe('review-apps', () => {
 					status: 'created'
 				});
 
-			const waitedReviewAppBuild = await waitTillReviewAppCreated({ reviewApp });
+			const waitedReviewAppBuild = await repeatedCheckForReviewAppCreatedStatus({ reviewApp });
 
 			expect(waitedReviewAppBuild).toEqual(appId);
 
@@ -547,7 +547,7 @@ describe('review-apps', () => {
 					status: 'created'
 				});
 
-			const waitedReviewAppBuild = await waitTillReviewAppCreated({ reviewApp, minTimeout: 0 });
+			const waitedReviewAppBuild = await repeatedCheckForReviewAppCreatedStatus({ reviewApp, minTimeout: 0 });
 			expect(waitedReviewAppBuild).toEqual(appId);
 
 		});
@@ -569,7 +569,7 @@ describe('review-apps', () => {
 					status: 'created'
 				});
 
-			const waitedReviewAppBuild = await waitTillReviewAppCreated({ reviewApp, minTimeout: 0 });
+			const waitedReviewAppBuild = await repeatedCheckForReviewAppCreatedStatus({ reviewApp, minTimeout: 0 });
 			expect(waitedReviewAppBuild).toEqual(appId);
 
 		});
@@ -585,7 +585,7 @@ describe('review-apps', () => {
 				});
 
 			try {
-				await waitTillReviewAppCreated({ reviewApp });
+				await repeatedCheckForReviewAppCreatedStatus({ reviewApp });
 			} catch ({ message }) {
 				expect(message).toMatch('Review app was deleted');
 			}
@@ -603,7 +603,7 @@ describe('review-apps', () => {
 				});
 
 			try {
-				await waitTillReviewAppCreated({ reviewApp });
+				await repeatedCheckForReviewAppCreatedStatus({ reviewApp });
 			} catch ({ message }) {
 				expect(message).toMatch('Review app errored');
 			}
@@ -622,7 +622,7 @@ describe('review-apps', () => {
 				});
 
 			try {
-				await waitTillReviewAppCreated({ reviewApp });
+				await repeatedCheckForReviewAppCreatedStatus({ reviewApp });
 			} catch ({ message }) {
 				expect(message).toMatch('Review app errored');
 			}
@@ -658,7 +658,7 @@ describe('review-apps', () => {
 				]);
 
 			try {
-				await waitTillReviewAppCreated({ reviewApp, commit });
+				await repeatedCheckForReviewAppCreatedStatus({ reviewApp, commit });
 			} catch (error) {
 				expect(console.error.mock.calls[0][0]).toMatch('https://heroku.com/builds/output/app123'); // eslint-disable-line no-console
 			}
@@ -684,7 +684,7 @@ describe('review-apps', () => {
 				.reply(400);
 
 			try {
-				await waitTillReviewAppCreated({ reviewApp });
+				await repeatedCheckForReviewAppCreatedStatus({ reviewApp });
 			} catch (error) {
 				expect(console.error.mock.calls[0][0]).toMatch('Could not get app build'); // eslint-disable-line no-console
 			}
@@ -702,7 +702,7 @@ describe('review-apps', () => {
 				.reply(200, []);
 
 			try {
-				await waitTillReviewAppCreated({ reviewApp, minTimeout: 0 });
+				await repeatedCheckForReviewAppCreatedStatus({ reviewApp, minTimeout: 0 });
 			} catch ({ message }) {
 				expect(message).toMatch('Review app not created yet');
 			}

--- a/lib/review-apps.unit.test.js
+++ b/lib/review-apps.unit.test.js
@@ -114,14 +114,14 @@ describe('review-apps', () => {
 			reviewAppsNockScope.post('/review-apps')
 				.reply(200, {});
 
-			return createReviewApp({ pipelineId, branch, repoName, commit, githubToken })
-				.then(async res => {
-					const { ok } = res;
-					expect(ok).toBeTruthy();
+			const response = await createReviewApp({ pipelineId, branch, repoName, commit, githubToken });
 
-					const reviewApp = await res.json();
-					expect(reviewApp).toBeTruthy();
-				});
+			const { ok } = response;
+
+			const reviewApp = await response.json();
+
+			expect(ok).toBeTruthy();
+			expect(reviewApp).toBeTruthy();
 
 		});
 
@@ -136,14 +136,14 @@ describe('review-apps', () => {
 			reviewAppsNockScope.post('/review-apps')
 				.reply(400, {});
 
-			return createReviewApp({ pipelineId, branch, repoName, commit, githubToken })
-				.then(async res => {
-					const { ok } = res;
-					expect(ok).toBeFalsy();
+			const response = await createReviewApp({ pipelineId, branch, repoName, commit, githubToken });
 
-					const error = await res.json();
-					expect(error).toBeTruthy();
-				});
+			const { ok } = response;
+
+			const error = await response.json();
+
+			expect(ok).toBeFalsy();
+			expect(error).toBeTruthy();
 
 		});
 
@@ -584,11 +584,11 @@ describe('review-apps', () => {
 					status: 'deleted'
 				});
 
-			return waitTillReviewAppCreated({ reviewApp })
-				.catch(error => {
-					const { message } = error;
-					expect(message).toMatch('Review app was deleted');
-				});
+			try {
+				await waitTillReviewAppCreated({ reviewApp });
+			} catch ({ message }) {
+				expect(message).toMatch('Review app was deleted');
+			}
 
 		});
 
@@ -602,11 +602,11 @@ describe('review-apps', () => {
 					status: 'errored'
 				});
 
-			return waitTillReviewAppCreated({ reviewApp })
-				.catch(error => {
-					const { message } = error;
-					expect(message).toMatch('Review app errored');
-				});
+			try {
+				await waitTillReviewAppCreated({ reviewApp });
+			} catch ({ message }) {
+				expect(message).toMatch('Review app errored');
+			}
 
 		});
 
@@ -621,11 +621,11 @@ describe('review-apps', () => {
 					status: 'errored'
 				});
 
-			return waitTillReviewAppCreated({ reviewApp })
-				.catch(error => {
-					const { message } = error;
-					expect(message).toMatch('Review app errored');
-				});
+			try {
+				await waitTillReviewAppCreated({ reviewApp });
+			} catch ({ message }) {
+				expect(message).toMatch('Review app errored');
+			}
 
 		});
 
@@ -657,10 +657,11 @@ describe('review-apps', () => {
 					}
 				]);
 
-			return waitTillReviewAppCreated({ reviewApp, commit })
-				.catch(() => {
-					expect(console.error.mock.calls[0][0]).toMatch('https://heroku.com/builds/output/app123'); // eslint-disable-line no-console
-				});
+			try {
+				await waitTillReviewAppCreated({ reviewApp, commit });
+			} catch (error) {
+				expect(console.error.mock.calls[0][0]).toMatch('https://heroku.com/builds/output/app123'); // eslint-disable-line no-console
+			}
 
 		});
 
@@ -682,10 +683,11 @@ describe('review-apps', () => {
 			nockScope.get('/apps/app123/builds')
 				.reply(400);
 
-			return waitTillReviewAppCreated({ reviewApp })
-				.catch(() => {
-					expect(console.error.mock.calls[0][0]).toMatch('Could not get app build'); // eslint-disable-line no-console
-				});
+			try {
+				await waitTillReviewAppCreated({ reviewApp });
+			} catch (error) {
+				expect(console.error.mock.calls[0][0]).toMatch('Could not get app build'); // eslint-disable-line no-console
+			}
 
 		});
 
@@ -699,11 +701,12 @@ describe('review-apps', () => {
 				.times(60)
 				.reply(200, []);
 
-			return waitTillReviewAppCreated({ reviewApp, minTimeout: 0 })
-				.catch((error) => {
-					const { message } = error;
-					expect(message).toMatch('Review app not created yet');
-				});
+			try {
+				await waitTillReviewAppCreated({ reviewApp, minTimeout: 0 });
+			} catch ({ message }) {
+				expect(message).toMatch('Review app not created yet');
+			}
+
 		});
 
 	});

--- a/lib/review-apps.unit.test.js
+++ b/lib/review-apps.unit.test.js
@@ -145,7 +145,7 @@ describe('review-apps', () => {
 				.reply(200, {
 					name: 'the-app'
 				});
-			const name = await getAppName(appId);
+			const name = await getAppName({ appId });
 			expect(name).toEqual('the-app');
 		});
 
@@ -157,7 +157,7 @@ describe('review-apps', () => {
 				});
 
 			try {
-				await getAppName(appId);
+				await getAppName({ appId });
 			} catch (error) {
 				expect(error.message).toEqual('Some error occurred');
 			}
@@ -236,6 +236,7 @@ describe('review-apps', () => {
 
 		it('returns appId of succeeded review app build', async () => {
 			const commit = 'a00000000000';
+			const reviewAppId = 'reviewApp123';
 			const appId = 'app123';
 			const reviewAppBuild = {
 				app: {
@@ -251,39 +252,38 @@ describe('review-apps', () => {
 
 			const waitedReviewAppBuild = await waitForReviewAppBuild({
 				commit
-			})(appId);
+			})({ reviewAppId, appId });
 
-			expect(waitedReviewAppBuild).toEqual(appId);
+			expect(waitedReviewAppBuild).toEqual({ appId });
 		});
 
-		it('waits for succeeded review app build from no review apps', async () => {
+		it('will delete review app and throw error in event of no review app build for commit', async () => {
 			const commit = 'a00000000000';
+			const reviewAppId = 'reviewApp123';
 			const appId = 'app123';
-			const succeededReviewAppBuild = {
-				app: {
-					id: appId
-				},
-				source_blob: {
-					version: commit
-				},
-				status: 'succeeded'
-			};
 			nockScope
 				.get('/apps/app123/builds')
-				.reply(200, [])
-				.get('/apps/app123/builds')
-				.reply(200, [ succeededReviewAppBuild ]);
+				.reply(200, []);
+			reviewAppsNockScope
+				.delete('/review-apps/reviewApp123')
+				.reply(200);
 
-			const waitedReviewAppBuild = await waitForReviewAppBuild({
-				commit,
-				minTimeout: 0
-			})(appId);
-
-			expect(waitedReviewAppBuild).toEqual(appId);
+			try {
+				await waitForReviewAppBuild({
+					commit,
+					minTimeout: 0
+				})({ reviewAppId, appId });
+			} catch (error) {
+				const { message } = error;
+				expect(message).toMatch('No review app build found for app id');
+				expect(message).toMatch('The presence of a review app without a corresponding build is likely the result of a rebase');
+				expect(message).toMatch('The review app has been deleted and a rebuild will now be attempted');
+			}
 		});
 
 		it('waits for succeeded review app build even with errors', async () => {
 			const commit = 'a00000000000';
+			const reviewAppId = 'reviewApp123';
 			const appId = 'app123';
 			const succeededReviewAppBuild = {
 				app: {
@@ -303,13 +303,14 @@ describe('review-apps', () => {
 			const waitedReviewAppBuild = await waitForReviewAppBuild({
 				commit,
 				minTimeout: 0
-			})(appId);
+			})({ reviewAppId, appId });
 
-			expect(waitedReviewAppBuild).toEqual(appId);
+			expect(waitedReviewAppBuild).toEqual({ appId });
 		});
 
 		it('waits for succeeded review app build from pending', async () => {
 			const commit = 'a00000000000';
+			const reviewAppId = 'reviewApp123';
 			const appId = 'app123';
 			const pendingReviewAppBuild = {
 				source_blob: {
@@ -335,13 +336,14 @@ describe('review-apps', () => {
 			const waitedReviewAppBuild = await waitForReviewAppBuild({
 				commit,
 				minTimeout: 0
-			})(appId);
+			})({ reviewAppId, appId });
 
-			expect(waitedReviewAppBuild).toEqual(appId);
+			expect(waitedReviewAppBuild).toEqual({ appId });
 		});
 
 		it('fails for failed review app build with output stream link', async () => {
 			const commit = 'a00000000000';
+			const reviewAppId = 'reviewApp123';
 			const appId = 'app123';
 			const failedReviewAppBuild = {
 				source_blob: {
@@ -358,7 +360,7 @@ describe('review-apps', () => {
 				await waitForReviewAppBuild({
 					commit,
 					minTimeout: 0
-				})(appId);
+				})({ reviewAppId, appId });
 			} catch (e) {
 				const { message } = e;
 				expect(message).toMatch('Review app build failed');
@@ -368,19 +370,26 @@ describe('review-apps', () => {
 
 		it('times out', async () => {
 			const commit = 'a00000000000';
+			const reviewAppId = 'reviewApp123';
 			const appId = 'app123';
+			const pendingReviewAppBuild = {
+				source_blob: {
+					version: commit
+				},
+				status: 'pending'
+			};
 			nockScope
 				.get('/apps/app123/builds')
 				.times(60)
-				.reply(200, []);
+				.reply(200, [ pendingReviewAppBuild ]);
 
 			return waitForReviewAppBuild({
 				commit,
 				minTimeout: 0
-			})(appId)
+			})({ reviewAppId, appId })
 				.catch((error) => {
 					const { message } = error;
-					expect(message).toMatch('No review app build found');
+					expect(message).toMatch('Review app build for app id \'app123\' (commit \'a00000000000\') not done yet: pending');
 				});
 		});
 	});
@@ -404,7 +413,7 @@ describe('review-apps', () => {
 
 			const waitedReviewAppBuild = await waitTillReviewAppCreated()(reviewApp);
 
-			expect(waitedReviewAppBuild).toEqual(appId);
+			expect(waitedReviewAppBuild).toEqual({ reviewAppId, appId });
 		});
 
 		it('waits for review app id until created', async () => {
@@ -433,7 +442,7 @@ describe('review-apps', () => {
 				minTimeout: 0
 			})(reviewApp);
 
-			expect(waitedReviewAppBuild).toEqual(appId);
+			expect(waitedReviewAppBuild).toEqual({ reviewAppId, appId });
 		});
 
 		it('waits for review app id even if there is a http error', async () => {
@@ -457,7 +466,7 @@ describe('review-apps', () => {
 				minTimeout: 0
 			})(reviewApp);
 
-			expect(waitedReviewAppBuild).toEqual(appId);
+			expect(waitedReviewAppBuild).toEqual({ reviewAppId, appId });
 		});
 
 		it('throws error if review app status is deleted', async () => {
@@ -651,7 +660,7 @@ describe('review-apps', () => {
 			expect(name).toEqual(appName);
 		});
 
-		it('throws an error if review app is deleted', async () => {
+		it('throws an error if review app is deleted on two subsequent attempts', async () => {
 			const appName = 'next-app';
 			const repoName = 'next-app-repo';
 			const branch = 'new-idea-branch';
@@ -663,16 +672,19 @@ describe('review-apps', () => {
 			const appId = 'app123';
 
 			nockScope.get('/pipelines/next-app')
+				.times(2)
 				.reply(200, {
 					id: pipelineId
 				});
 			reviewAppsNockScope
 				.post('/review-apps')
+				.times(2)
 				.reply(409, {
 					id: 'conflict',
 					message: 'A review app already exists for the post-build branch'
 				})
 				.get('/pipelines/pipelineId/review-apps')
+				.times(2)
 				.reply(200, [
 					{
 						id: reviewAppId,
@@ -680,6 +692,7 @@ describe('review-apps', () => {
 					}
 				])
 				.get('/review-apps/reviewAppId')
+				.times(2)
 				.reply(200, {
 					status: 'deleted',
 					app: {
@@ -693,14 +706,15 @@ describe('review-apps', () => {
 					repoName,
 					branch,
 					commit,
-					githubToken
+					githubToken,
+					minTimeout: 0
 				});
 			} catch ({ message }) {
 				expect(message).toMatch('Review app was deleted');
 			}
 		});
 
-		it('throws an error if review app errors', async () => {
+		it('throws an error if review app errors on two subsequent attempts', async () => {
 			const appName = 'next-app';
 			const repoName = 'next-app-repo';
 			const branch = 'new-idea-branch';
@@ -717,11 +731,13 @@ describe('review-apps', () => {
 				});
 			reviewAppsNockScope
 				.post('/review-apps')
+				.times(2)
 				.reply(409, {
 					id: 'conflict',
 					message: 'A review app already exists for the post-build branch'
 				})
 				.get('/pipelines/pipelineId/review-apps')
+				.times(2)
 				.reply(200, [
 					{
 						id: reviewAppId,
@@ -729,6 +745,7 @@ describe('review-apps', () => {
 					}
 				])
 				.get('/review-apps/reviewAppId')
+				.times(2)
 				.reply(200, {
 					status: 'errored',
 					app: {
@@ -742,7 +759,8 @@ describe('review-apps', () => {
 					repoName,
 					branch,
 					commit,
-					githubToken
+					githubToken,
+					minTimeout: 0
 				});
 			} catch ({ message }) {
 				expect(message).toMatch('Review app errored');

--- a/lib/review-apps.unit.test.js
+++ b/lib/review-apps.unit.test.js
@@ -111,8 +111,28 @@ describe('review-apps', () => {
 			const commit = 'a00000000000';
 			const githubToken = '';
 
-			reviewAppsNockScope.post('/review-apps')
-				.reply(200, {});
+			const reviewAppResponse = {
+				app: {
+					id: 'app123'
+				},
+				branch,
+				pipeline: {
+					id: pipelineId
+				},
+				status: 'succeeded'
+			};
+
+			const requestBody = {
+				pipeline: pipelineId,
+				branch,
+				source_blob: {
+					url: 'https://github.com/some-tarball-link',
+					version: commit
+				}
+			};
+
+			reviewAppsNockScope.post('/review-apps', JSON.stringify(requestBody))
+				.reply(200, reviewAppResponse);
 
 			const response = await createReviewApp({ pipelineId, branch, repoName, commit, githubToken });
 
@@ -121,7 +141,7 @@ describe('review-apps', () => {
 			const reviewApp = await response.json();
 
 			expect(ok).toBeTruthy();
-			expect(reviewApp).toBeTruthy();
+			expect(reviewApp).toEqual(reviewAppResponse);
 
 		});
 

--- a/lib/review-apps.unit.test.js
+++ b/lib/review-apps.unit.test.js
@@ -141,7 +141,7 @@ describe('review-apps', () => {
 
 		});
 
-		it('returns an error', async () => {
+		it('returns a response with an \'ok\' value of false if this is returned by the review-apps API', async () => {
 
 			const pipelineId = 'pipeline123';
 			const branch = 'some-branch';
@@ -156,10 +156,7 @@ describe('review-apps', () => {
 
 			const { ok } = response;
 
-			const error = await response.json();
-
 			expect(ok).toBeFalsy();
-			expect(error).toBeTruthy();
 
 		});
 

--- a/lib/review-apps.unit.test.js
+++ b/lib/review-apps.unit.test.js
@@ -1,5 +1,6 @@
 require('isomorphic-fetch');
 const nock = require('nock');
+const pRetry = require('p-retry');
 
 jest.mock('./github-api');
 const reviewApps = require('./review-apps');
@@ -28,6 +29,62 @@ describe('review-apps', () => {
 	afterEach(() => {
 		nock.cleanAll();
 		jest.resetAllMocks();
+	});
+
+	describe('handleNonSucceededReviewAppBuild', () => {
+
+		const { handleNonSucceededReviewAppBuild } = reviewApps;
+
+		it('returns without throwing an error if awaiting the review app build does not error', async () => {
+
+			const commit = 'a00000000000';
+			const appId = 'app123';
+
+			nockScope
+				.get('/apps/app123/builds')
+				.reply(200, [
+					{
+						status: 'succeeded',
+						app: {
+							id: appId
+						},
+						source_blob: {
+							version: commit
+						}
+					}
+				]);
+
+			try {
+				await handleNonSucceededReviewAppBuild({ commit, appId, minTimeout: 0 });
+			} catch (error) {
+				expect(true).toBeFalsy();
+			}
+
+			expect(true).toBeTruthy();
+
+		});
+
+		it('throws pRetry.AbortError if the awaiting the review app build errors', async () => {
+
+			const commit = 'a00000000000';
+			const appId = 'app123';
+
+			nockScope
+				.get('/apps/app123/builds')
+				.times(60)
+				.reply(400, {
+					message: 'Some error occurred'
+				});
+
+			try {
+				await handleNonSucceededReviewAppBuild({ commit, appId, minTimeout: 0 });
+			} catch (error) {
+				expect(error.message).toMatch('Some error occurred');
+				expect(error).toBeInstanceOf(pRetry.AbortError);
+			}
+
+		});
+
 	});
 
 	describe('createReviewApp', () => {
@@ -136,6 +193,57 @@ describe('review-apps', () => {
 		});
 	});
 
+	describe('handleWaitTillReviewAppCreated', () => {
+
+		const { handleWaitTillReviewAppCreated } = reviewApps;
+
+		it('returns appId', async () => {
+
+			const appId = 'app123';
+			const commit = 'ababa';
+			const reviewAppId = 'reviewApp123';
+			const reviewApp = {
+				id: reviewAppId
+			};
+
+			reviewAppsNockScope.get('/review-apps/reviewApp123')
+				.reply(200, {
+					app: {
+						id: appId
+					},
+					status: 'created'
+				});
+
+			const returnedAppId = await handleWaitTillReviewAppCreated({ commit, reviewApp });
+			expect(returnedAppId).toEqual(appId);
+
+		});
+
+		it('throws pRetry.AbortError if an error when deleting the review app errors', async () => {
+
+			const commit = 'ababa';
+			const reviewAppId = 'reviewApp123';
+			const reviewApp = {
+				id: reviewAppId
+			};
+
+			reviewAppsNockScope.get('/review-apps/reviewApp123')
+				.times(60)
+				.reply(400, {
+					message: 'Some error occurred'
+				});
+
+			try {
+				await handleWaitTillReviewAppCreated({ commit, reviewApp, minTimeout: 0 });
+			} catch (error) {
+				expect(error.message).toMatch('Some error occurred');
+				expect(error).toBeInstanceOf(pRetry.AbortError);
+			}
+
+		});
+
+	});
+
 	describe('getAppName', () => {
 		const { getAppName } = reviewApps;
 
@@ -162,6 +270,60 @@ describe('review-apps', () => {
 				expect(error.message).toEqual('Some error occurred');
 			}
 		});
+	});
+
+	describe('deleteReviewApp', () => {
+
+		const { deleteReviewApp } = reviewApps;
+
+		it('throws error (to trigger retry of calling function) after successful deletion of review app', async () => {
+
+			const reviewAppId = 'reviewApp123';
+			const reviewApp = {
+				id: reviewAppId
+			};
+			const commit = 'ababa';
+			const appId = 'app123';
+
+			reviewAppsNockScope
+				.delete('/review-apps/reviewApp123')
+				.reply(200);
+
+			try {
+				await deleteReviewApp({ reviewApp, commit, appId });
+			} catch (error) {
+				expect(error.message).toMatch('No review app build found for app id \'app123\'; commit \'ababa\'');
+				expect(error.message).toMatch('The presence of a review app without a corresponding build is likely the result of a rebase.');
+				expect(error.message).toMatch('The review app has been deleted and a rebuild will now be attempted.');
+				expect(error).toBeInstanceOf(Error);
+			}
+
+		});
+
+		it('throws pRetry.AbortError if an error when deleting the review app errors', async () => {
+
+			const reviewAppId = 'reviewApp123';
+			const reviewApp = {
+				id: reviewAppId
+			};
+			const commit = 'ababa';
+			const appId = 'app123';
+
+			reviewAppsNockScope
+				.delete('/review-apps/reviewApp123')
+				.reply(400, {
+					message: 'Some error occurred'
+				});
+
+			try {
+				await deleteReviewApp({ reviewApp, commit, appId });
+			} catch (error) {
+				expect(error.message).toMatch('Some error occurred');
+				expect(error).toBeInstanceOf(pRetry.AbortError);
+			}
+
+		});
+
 	});
 
 	describe('getBuilds', () => {
@@ -231,179 +393,78 @@ describe('review-apps', () => {
 		});
 	});
 
-	describe.skip('waitForReviewAppBuild', () => {
-		const { waitForReviewAppBuild } = reviewApps;
+	describe('awaitReviewAppBuild', () => {
 
-		it('returns appId of succeeded review app build', async () => {
+		const { awaitReviewAppBuild } = reviewApps;
+
+		it('returns without throwing an error if the app build is returned with a status of \'succeeded\'', async () => {
+
 			const commit = 'a00000000000';
-			const reviewAppId = 'reviewApp123';
 			const appId = 'app123';
 			const reviewAppBuild = {
-				app: {
-					id: appId
-				},
 				source_blob: {
 					version: commit
 				},
 				status: 'succeeded'
 			};
+
 			nockScope.get('/apps/app123/builds')
-				.reply(200, [ reviewAppBuild ]);
-
-			const waitedReviewAppBuild = await waitForReviewAppBuild({
-				commit,
-				reviewAppId,
-				appId
-			});
-
-			expect(waitedReviewAppBuild).toEqual(appId);
-		});
-
-		it('will delete review app and throw error in event of no review app build for commit', async () => {
-			const commit = 'a00000000000';
-			const reviewAppId = 'reviewApp123';
-			const appId = 'app123';
-			nockScope
-				.get('/apps/app123/builds')
-				.reply(200, []);
-			reviewAppsNockScope
-				.delete('/review-apps/reviewApp123')
-				.reply(200);
+				.reply(200, [reviewAppBuild]);
 
 			try {
-				await waitForReviewAppBuild({
-					commit,
-					reviewAppId,
-					appId,
-					minTimeout: 0
-				});
+				await awaitReviewAppBuild({ commit, appId });
 			} catch (error) {
-				const { message } = error;
-				expect(message).toMatch('No review app build found for app id');
-				expect(message).toMatch('The presence of a review app without a corresponding build is likely the result of a rebase');
-				expect(message).toMatch('The review app has been deleted and a rebuild will now be attempted');
+				expect(true).toBeFalsy();
 			}
+
+			expect(true).toBeTruthy();
+
 		});
 
-		it('waits for succeeded review app build even with errors', async () => {
+		it('will retry if an error is thrown when attempting to get the app build status', async () => {
+
 			const commit = 'a00000000000';
-			const reviewAppId = 'reviewApp123';
 			const appId = 'app123';
-			const succeededReviewAppBuild = {
-				app: {
-					id: appId
-				},
-				source_blob: {
-					version: commit
-				},
-				status: 'succeeded'
-			};
-			nockScope
-				.get('/apps/app123/builds')
-				.reply(400, [])
-				.get('/apps/app123/builds')
-				.reply(200, [ succeededReviewAppBuild ]);
 
-			const waitedReviewAppBuild = await waitForReviewAppBuild({
-				commit,
-				reviewAppId,
-				appId,
-				minTimeout: 0
-			});
-
-			expect(waitedReviewAppBuild).toEqual(appId);
-		});
-
-		it('waits for succeeded review app build from pending', async () => {
-			const commit = 'a00000000000';
-			const reviewAppId = 'reviewApp123';
-			const appId = 'app123';
-			const pendingReviewAppBuild = {
-				source_blob: {
-					version: commit
-				},
-				status: 'pending'
-			};
-			const succeededReviewAppBuild = {
-				app: {
-					id: appId
-				},
-				source_blob: {
-					version: commit
-				},
-				status: 'succeeded'
-			};
-			nockScope
-				.get('/apps/app123/builds')
-				.reply(200, [ pendingReviewAppBuild ])
-				.get('/apps/app123/builds')
-				.reply(200, [ succeededReviewAppBuild ]);
-
-			const waitedReviewAppBuild = await waitForReviewAppBuild({
-				commit,
-				reviewAppId,
-				appId,
-				minTimeout: 0
-			});
-
-			expect(waitedReviewAppBuild).toEqual(appId);
-		});
-
-		it('fails for failed review app build with output stream link', async () => {
-			const commit = 'a00000000000';
-			const reviewAppId = 'reviewApp123';
-			const appId = 'app123';
-			const failedReviewAppBuild = {
-				source_blob: {
-					version: commit
-				},
-				status: 'failed',
-				output_stream_url: 'https://heroku.com/builds/output/app123'
-			};
-			nockScope
-				.get('/apps/app123/builds')
-				.reply(200, [ failedReviewAppBuild ]);
+			nockScope.get('/apps/app123/builds')
+				.times(60)
+				.reply(400, {
+					message: 'Some error occurred'
+				});
 
 			try {
-				await waitForReviewAppBuild({
-					commit,
-					reviewAppId,
-					appId,
-					minTimeout: 0
-				});
-			} catch (e) {
-				const { message } = e;
-				expect(message).toMatch('Review app build failed');
-				expect(message).toMatch('https://heroku.com/builds/output/app123');
+				await awaitReviewAppBuild({ commit, appId, minTimeout: 0 });
+			} catch (error) {
+				expect(error.message).toMatch('Some error occurred');
+				expect(error).toBeInstanceOf(Error);
 			}
+
 		});
 
-		it('times out', async () => {
+		it('will retry if the build returned does not have a status of \'succeeded\'', async () => {
+
 			const commit = 'a00000000000';
-			const reviewAppId = 'reviewApp123';
 			const appId = 'app123';
-			const pendingReviewAppBuild = {
+			const reviewAppBuild = {
 				source_blob: {
 					version: commit
 				},
 				status: 'pending'
 			};
-			nockScope
-				.get('/apps/app123/builds')
-				.times(60)
-				.reply(200, [ pendingReviewAppBuild ]);
 
-			return waitForReviewAppBuild({
-				commit,
-				reviewAppId,
-				appId,
-				minTimeout: 0
-			})
-				.catch((error) => {
-					const { message } = error;
-					expect(message).toMatch('Review app build for app id \'app123\' (commit \'a00000000000\') not done yet: pending');
-				});
+			nockScope.get('/apps/app123/builds')
+				.times(60)
+				.reply(200, [reviewAppBuild]);
+
+			try {
+				await awaitReviewAppBuild({ commit, appId, minTimeout: 0 });
+			} catch (error) {
+				expect(error.message).toMatch('Review app build for app id \'app123\' (commit \'a00000000000\') not done yet: pending');
+				expect(error).toBeInstanceOf(Error);
+			}
+
 		});
+
 	});
 
 	describe('waitTillReviewAppCreated', () => {
@@ -608,110 +669,214 @@ describe('review-apps', () => {
 	});
 
 	describe('getReviewAppName', () => {
+
 		const { getReviewAppName } = reviewApps;
 
-		it('creates a new review app build if a review app already exists', async () => {
-			const appName = 'next-app';
-			const repoName = 'next-app-repo';
-			const branch = 'new-idea-branch';
-			const commit = 'a123';
-			const githubToken = 'github-token-123';
+		describe('attempt to create review app for branch responds that it already exists', () => {
 
-			const pipelineId = 'pipelineId';
-			const reviewAppId = 'reviewAppId';
-			const appId = 'app123';
+			it('throws error if it cannot find review app in pipeline for specified branch', async () => {
 
-			nockScope
-				.get('/pipelines/next-app')
-				.reply(200, {
-					id: pipelineId
-				})
-				.get('/apps/app123/builds')
-				.reply(200, [
-					{
-						status: 'succeeded',
+				const appName = 'next-app';
+				const repoName = 'next-app-repo';
+				const branch = 'new-idea-branch';
+				const commit = 'a123';
+				const githubToken = 'github-token-123';
+
+				const pipelineId = 'pipelineId';
+
+				nockScope
+					.get('/pipelines/next-app')
+					.reply(200, {
+						id: pipelineId
+					});
+
+				reviewAppsNockScope
+					.post('/review-apps')
+					.reply(409, {
+						id: 'conflict',
+						message: 'A review app already exists for the post-build branch'
+					})
+					.get('/pipelines/pipelineId/review-apps')
+					.reply(200, []);
+
+				try {
+					await getReviewAppName({ appName, repoName, branch, commit, githubToken });
+				} catch ({ message }) {
+					expect(message).toMatch('No review app found for pipeline pipelineId, branch new-idea-branch');
+				}
+
+			});
+
+			it('throws error if it can find review app in pipeline for specified branch but its status is \'deleted\'', async () => {
+
+				const appName = 'next-app';
+				const repoName = 'next-app-repo';
+				const branch = 'new-idea-branch';
+				const commit = 'a123';
+				const githubToken = 'github-token-123';
+
+				const pipelineId = 'pipelineId';
+				const reviewAppId = 'reviewAppId';
+				const appId = 'app123';
+
+				nockScope.get('/pipelines/next-app')
+					.reply(200, {
+						id: pipelineId
+					});
+
+				reviewAppsNockScope
+					.post('/review-apps')
+					.reply(409, {
+						id: 'conflict',
+						message: 'A review app already exists for the post-build branch'
+					})
+					.get('/pipelines/pipelineId/review-apps')
+					.reply(200, [
+						{
+							id: reviewAppId,
+							branch
+						}
+					])
+					.get('/review-apps/reviewAppId')
+					.reply(200, {
+						status: 'deleted',
 						app: {
 							id: appId
-						},
-						source_blob: {
-							version: commit
 						}
-					}
-				])
-				.get('/apps/app123')
-				.reply(200, {
-					name: appName
-				});
-			reviewAppsNockScope
-				.post('/review-apps')
-				.reply(409, {
-					id: 'conflict',
-					message: 'A review app already exists for the post-build branch'
-				})
-				.get('/pipelines/pipelineId/review-apps')
-				.reply(200, [
-					{
-						id: reviewAppId,
-						branch
-					}
-				])
-				.get('/review-apps/reviewAppId')
-				.reply(200, {
-					status: 'created',
-					app: {
-						id: appId
-					}
-				});
+					});
 
-			const name = await getReviewAppName({
-				appName,
-				repoName,
-				branch,
-				commit,
-				githubToken
+				try {
+					await getReviewAppName({
+						appName,
+						repoName,
+						branch,
+						commit,
+						githubToken,
+						minTimeout: 0
+					});
+				} catch ({ message }) {
+					expect(message).toMatch('Review app was deleted');
+				}
+
 			});
 
-			expect(name).toEqual(appName);
-		});
+			it('throws error if it can find review app in pipeline for specified branch but its status is \'errored\'', async () => {
 
-		it('throws an error if review app is deleted', async () => {
-			const appName = 'next-app';
-			const repoName = 'next-app-repo';
-			const branch = 'new-idea-branch';
-			const commit = 'a123';
-			const githubToken = 'github-token-123';
+				const appName = 'next-app';
+				const repoName = 'next-app-repo';
+				const branch = 'new-idea-branch';
+				const commit = 'a123';
+				const githubToken = 'github-token-123';
 
-			const pipelineId = 'pipelineId';
-			const reviewAppId = 'reviewAppId';
-			const appId = 'app123';
+				const pipelineId = 'pipelineId';
+				const reviewAppId = 'reviewAppId';
+				const appId = 'app123';
 
-			nockScope.get('/pipelines/next-app')
-				.reply(200, {
-					id: pipelineId
-				});
-			reviewAppsNockScope
-				.post('/review-apps')
-				.reply(409, {
-					id: 'conflict',
-					message: 'A review app already exists for the post-build branch'
-				})
-				.get('/pipelines/pipelineId/review-apps')
-				.reply(200, [
-					{
+				nockScope.get('/pipelines/next-app')
+					.reply(200, {
+						id: pipelineId
+					});
+				reviewAppsNockScope
+					.post('/review-apps')
+					.reply(409, {
+						id: 'conflict',
+						message: 'A review app already exists for the post-build branch'
+					})
+					.get('/pipelines/pipelineId/review-apps')
+					.reply(200, [
+						{
+							id: reviewAppId,
+							branch
+						}
+					])
+					.get('/review-apps/reviewAppId')
+					.reply(200, {
+						status: 'errored',
+						app: {
+							id: appId
+						}
+					});
+
+				try {
+					await getReviewAppName({
+						appName,
+						repoName,
+						branch,
+						commit,
+						githubToken,
+						minTimeout: 0
+					});
+				} catch ({ message }) {
+					expect(message).toMatch('Review app errored');
+					expect(message).toMatch(appId);
+				}
+
+			});
+
+			it('deletes review app if it cannot find corresponding build for commit; then recreates review app and returns its name', async () => {
+
+				const appName = 'next-app';
+				const repoName = 'next-app-repo';
+				const branch = 'new-idea-branch';
+				const commit = 'a123';
+				const githubToken = 'github-token-123';
+
+				const pipelineId = 'pipelineId';
+				const reviewAppId = 'reviewAppId';
+				const appId = 'app123';
+
+				nockScope
+					.get('/pipelines/next-app')
+					.reply(200, {
+						id: pipelineId
+					})
+					.get('/apps/app123/builds')
+					.reply(200, [
+						{
+							status: 'succeeded',
+							app: {
+								id: appId
+							},
+							source_blob: {
+								version: 'b456' // i.e. does not match `commit`.
+							}
+						}
+					])
+					.get('/apps/app123')
+					.reply(200, {
+						name: appName
+					});
+
+				reviewAppsNockScope
+					.post('/review-apps')
+					.reply(409, {
+						id: 'conflict',
+						message: 'A review app already exists for the post-build branch'
+					})
+					.get('/pipelines/pipelineId/review-apps')
+					.reply(200, [
+						{
+							id: reviewAppId,
+							branch
+						}
+					])
+					.get('/review-apps/reviewAppId')
+					.times(2)
+					.reply(200, {
+						status: 'created',
+						app: {
+							id: appId
+						}
+					})
+					.delete('/review-apps/reviewAppId')
+					.reply(200)
+					.post('/review-apps')
+					.reply(200, {
 						id: reviewAppId,
-						branch
-					}
-				])
-				.get('/review-apps/reviewAppId')
-				.reply(200, {
-					status: 'deleted',
-					app: {
-						id: appId
-					}
-				});
+						status: 'created'
+					});
 
-			try {
-				await getReviewAppName({
+				const name = await getReviewAppName({
 					appName,
 					repoName,
 					branch,
@@ -719,49 +884,204 @@ describe('review-apps', () => {
 					githubToken,
 					minTimeout: 0
 				});
-			} catch ({ message }) {
-				expect(message).toMatch('Review app was deleted');
-			}
-		});
 
-		it('throws an error if review app errors', async () => {
-			const appName = 'next-app';
-			const repoName = 'next-app-repo';
-			const branch = 'new-idea-branch';
-			const commit = 'a123';
-			const githubToken = 'github-token-123';
+				expect(name).toEqual(appName);
 
-			const pipelineId = 'pipelineId';
-			const reviewAppId = 'reviewAppId';
-			const appId = 'app123';
+			});
 
-			nockScope.get('/pipelines/next-app')
-				.reply(200, {
-					id: pipelineId
+			it('creates a new review app build if a review app already exists; then returns its name', async () => {
+
+				const appName = 'next-app';
+				const repoName = 'next-app-repo';
+				const branch = 'new-idea-branch';
+				const commit = 'a123';
+				const githubToken = 'github-token-123';
+
+				const pipelineId = 'pipelineId';
+				const reviewAppId = 'reviewAppId';
+				const appId = 'app123';
+
+				nockScope
+					.get('/pipelines/next-app')
+					.reply(200, {
+						id: pipelineId
+					})
+					.get('/apps/app123/builds')
+					.reply(200, [
+						{
+							status: 'succeeded',
+							app: {
+								id: appId
+							},
+							source_blob: {
+								version: commit
+							}
+						}
+					])
+					.get('/apps/app123')
+					.reply(200, {
+						name: appName
+					});
+
+				reviewAppsNockScope
+					.post('/review-apps')
+					.reply(409, {
+						id: 'conflict',
+						message: 'A review app already exists for the post-build branch'
+					})
+					.get('/pipelines/pipelineId/review-apps')
+					.reply(200, [
+						{
+							id: reviewAppId,
+							branch
+						}
+					])
+					.get('/review-apps/reviewAppId')
+					.reply(200, {
+						status: 'created',
+						app: {
+							id: appId
+						}
+					});
+
+				const name = await getReviewAppName({
+					appName,
+					repoName,
+					branch,
+					commit,
+					githubToken
 				});
-			reviewAppsNockScope
-				.post('/review-apps')
-				.reply(409, {
-					id: 'conflict',
-					message: 'A review app already exists for the post-build branch'
-				})
-				.get('/pipelines/pipelineId/review-apps')
-				.reply(200, [
-					{
-						id: reviewAppId,
-						branch
-					}
-				])
-				.get('/review-apps/reviewAppId')
-				.reply(200, {
-					status: 'errored',
-					app: {
-						id: appId
-					}
-				});
 
-			try {
-				await getReviewAppName({
+				expect(name).toEqual(appName);
+
+			});
+
+			it('errors if review app build status is \'errored\' and includes output stream link in the error message', async () => {
+
+				const appName = 'next-app';
+				const repoName = 'next-app-repo';
+				const branch = 'new-idea-branch';
+				const commit = 'a123';
+				const githubToken = 'github-token-123';
+
+				const pipelineId = 'pipelineId';
+				const reviewAppId = 'reviewAppId';
+				const appId = 'app123';
+
+				nockScope
+					.get('/pipelines/next-app')
+					.reply(200, {
+						id: pipelineId
+					})
+					.get('/apps/app123/builds')
+					.reply(200, [
+						{
+							source_blob: {
+								version: commit
+							},
+							status: 'failed',
+							output_stream_url: 'https://heroku.com/builds/output/app123'
+						}
+					]);
+
+				reviewAppsNockScope
+					.post('/review-apps')
+					.reply(409, {
+						id: 'conflict',
+						message: 'A review app already exists for the post-build branch'
+					})
+					.get('/pipelines/pipelineId/review-apps')
+					.reply(200, [
+						{
+							id: reviewAppId,
+							branch
+						}
+					])
+					.get('/review-apps/reviewAppId')
+					.reply(200, {
+						status: 'created',
+						app: {
+							id: appId
+						}
+					});
+
+				try {
+					await getReviewAppName({ appName, repoName, branch, commit, githubToken });
+				} catch (error) {
+					expect(error.message).toMatch('Review app build failed');
+					expect(error.message).toMatch('https://heroku.com/builds/output/app123');
+				}
+
+			});
+
+			it('waits for pending review app build to finish by retrying until the build status is \'succeeded\'', async () => {
+
+				const appName = 'next-app';
+				const repoName = 'next-app-repo';
+				const branch = 'new-idea-branch';
+				const commit = 'a123';
+				const githubToken = 'github-token-123';
+
+				const pipelineId = 'pipelineId';
+				const reviewAppId = 'reviewAppId';
+				const appId = 'app123';
+
+				nockScope
+					.get('/pipelines/next-app')
+					.reply(200, {
+						id: pipelineId
+					})
+					.get('/apps/app123/builds')
+					.reply(200, [
+						{
+							status: 'pending',
+							app: {
+								id: appId
+							},
+							source_blob: {
+								version: commit
+							}
+						}
+					])
+					.get('/apps/app123/builds')
+					.reply(200, [
+						{
+							status: 'succeeded',
+							app: {
+								id: appId
+							},
+							source_blob: {
+								version: commit
+							}
+						}
+					])
+					.get('/apps/app123')
+					.reply(200, {
+						name: appName
+					});
+
+				reviewAppsNockScope
+					.post('/review-apps')
+					.reply(409, {
+						id: 'conflict',
+						message: 'A review app already exists for the post-build branch'
+					})
+					.get('/pipelines/pipelineId/review-apps')
+					.reply(200, [
+						{
+							id: reviewAppId,
+							branch
+						}
+					])
+					.get('/review-apps/reviewAppId')
+					.reply(200, {
+						status: 'created',
+						app: {
+							id: appId
+						}
+					});
+
+				const name = await getReviewAppName({
 					appName,
 					repoName,
 					branch,
@@ -769,55 +1089,124 @@ describe('review-apps', () => {
 					githubToken,
 					minTimeout: 0
 				});
-			} catch ({ message }) {
-				expect(message).toMatch('Review app errored');
-				expect(message).toMatch(appId);
-			}
-		});
 
-		it('gets review app name', async () => {
-			const appName = 'next-app';
-			const repoName = 'next-app-repo';
-			const branch = 'new-idea-branch';
-			const commit = 'a123';
-			const githubToken = 'github-token-123';
+				expect(name).toEqual(appName);
 
-			const pipelineId = 'pipelineId';
-			const reviewAppId = 'reviewAppId';
-			const appId = 'app123';
-
-			nockScope
-				.get('/pipelines/next-app')
-				.reply(200, {
-					id: pipelineId
-				})
-				.get('/apps/app123')
-				.reply(200, {
-					name: appName
-				});
-			reviewAppsNockScope
-				.post('/review-apps')
-				.reply(200, {
-					id: reviewAppId,
-					status: 'created'
-				})
-				.get('/review-apps/reviewAppId')
-				.reply(200, {
-					status: 'created',
-					app: {
-						id: appId
-					}
-				});
-
-			const name = await getReviewAppName({
-				appName,
-				repoName,
-				branch,
-				commit,
-				githubToken
 			});
 
-			expect(name).toEqual(appName);
+			it('times out if pending review app build does not achieve \'succeeded\' status after specified number of retries', async () => {
+
+				const appName = 'next-app';
+				const repoName = 'next-app-repo';
+				const branch = 'new-idea-branch';
+				const commit = 'a123';
+				const githubToken = 'github-token-123';
+
+				const pipelineId = 'pipelineId';
+				const reviewAppId = 'reviewAppId';
+				const appId = 'app123';
+
+				nockScope
+					.get('/pipelines/next-app')
+					.reply(200, {
+						id: pipelineId
+					})
+					.get('/apps/app123/builds')
+					.times(60)
+					.reply(200, [
+						{
+							status: 'pending',
+							app: {
+								id: appId
+							},
+							source_blob: {
+								version: commit
+							}
+						}
+					]);
+
+				reviewAppsNockScope
+					.post('/review-apps')
+					.reply(409, {
+						id: 'conflict',
+						message: 'A review app already exists for the post-build branch'
+					})
+					.get('/pipelines/pipelineId/review-apps')
+					.reply(200, [
+						{
+							id: reviewAppId,
+							branch
+						}
+					])
+					.get('/review-apps/reviewAppId')
+					.reply(200, {
+						status: 'created',
+						app: {
+							id: appId
+						}
+					});
+
+				try {
+					await getReviewAppName({ appName, repoName, branch, commit, githubToken, minTimeout: 0 });
+				} catch (error) {
+					expect(error.message).toMatch('Review app build for app id \'app123\' (commit \'a123\') not done yet: pending');
+				}
+
+			});
+
 		});
+
+		describe('attempt to create review app for branch responds that it does not yet exist', () => {
+
+			it('returns review app name', async () => {
+
+				const appName = 'next-app';
+				const repoName = 'next-app-repo';
+				const branch = 'new-idea-branch';
+				const commit = 'a123';
+				const githubToken = 'github-token-123';
+
+				const pipelineId = 'pipelineId';
+				const reviewAppId = 'reviewAppId';
+				const appId = 'app123';
+
+				nockScope
+					.get('/pipelines/next-app')
+					.reply(200, {
+						id: pipelineId
+					})
+					.get('/apps/app123')
+					.reply(200, {
+						name: appName
+					});
+
+				reviewAppsNockScope
+					.post('/review-apps')
+					.reply(200, {
+						id: reviewAppId,
+						status: 'created'
+					})
+					.get('/review-apps/reviewAppId')
+					.reply(200, {
+						status: 'created',
+						app: {
+							id: appId
+						}
+					});
+
+				const name = await getReviewAppName({
+					appName,
+					repoName,
+					branch,
+					commit,
+					githubToken
+				});
+
+				expect(name).toEqual(appName);
+
+			});
+
+		});
+
 	});
 });

--- a/lib/review-apps.unit.test.js
+++ b/lib/review-apps.unit.test.js
@@ -87,6 +87,7 @@ describe('review-apps', () => {
 			try {
 				await runCheckForBuildSuccessStatus({ commit, appId, minTimeout: 0 });
 			} catch (error) {
+				expect(nock.isDone()).toBeTruthy(); // i.e. Nock endpoints have been hit specified number of times.
 				expect(error.message).toMatch('Some error occurred');
 				expect(error).toBeInstanceOf(pRetry.AbortError);
 			}
@@ -253,6 +254,7 @@ describe('review-apps', () => {
 			try {
 				await runCheckForReviewAppCreatedStatus({ commit, reviewApp, minTimeout: 0 });
 			} catch (error) {
+				expect(nock.isDone()).toBeTruthy(); // i.e. Nock endpoints have been hit specified number of times.
 				expect(error.message).toMatch('Some error occurred');
 				expect(error).toBeInstanceOf(pRetry.AbortError);
 			}
@@ -478,6 +480,7 @@ describe('review-apps', () => {
 			try {
 				await repeatedCheckForBuildSuccessStatus({ commit, appId, minTimeout: 0 });
 			} catch (error) {
+				expect(nock.isDone()).toBeTruthy(); // i.e. Nock endpoints have been hit specified number of times.
 				expect(error.message).toMatch('Some error occurred');
 				expect(error).toBeInstanceOf(Error);
 			}
@@ -502,6 +505,7 @@ describe('review-apps', () => {
 			try {
 				await repeatedCheckForBuildSuccessStatus({ commit, appId, minTimeout: 0 });
 			} catch (error) {
+				expect(nock.isDone()).toBeTruthy(); // i.e. Nock endpoints have been hit specified number of times.
 				expect(error.message).toMatch('Review app build for app id \'app123\' (commit \'a00000000000\') not done yet: pending');
 				expect(error).toBeInstanceOf(Error);
 			}
@@ -713,6 +717,7 @@ describe('review-apps', () => {
 			try {
 				await repeatedCheckForReviewAppCreatedStatus({ reviewApp, minTimeout: 0 });
 			} catch ({ message }) {
+				expect(nock.isDone()).toBeTruthy(); // i.e. Nock endpoints have been hit specified number of times.
 				expect(message).toMatch('Review app not created yet');
 			}
 
@@ -915,6 +920,7 @@ describe('review-apps', () => {
 					});
 
 				const name = await getReviewAppName({ appName, repoName, branch, commit, githubToken, minTimeout: 0 });
+				expect(nock.isDone()).toBeTruthy(); // i.e. Nock endpoints have been hit specified number of times.
 				expect(name).toEqual(appName);
 
 			});
@@ -1164,6 +1170,7 @@ describe('review-apps', () => {
 				try {
 					await getReviewAppName({ appName, repoName, branch, commit, githubToken, minTimeout: 0 });
 				} catch (error) {
+					expect(nock.isDone()).toBeTruthy(); // i.e. Nock endpoints have been hit specified number of times.
 					expect(error.message).toMatch('Review app build for app id \'app123\' (commit \'a123\') not done yet: pending');
 				}
 

--- a/lib/review-apps.unit.test.js
+++ b/lib/review-apps.unit.test.js
@@ -145,7 +145,7 @@ describe('review-apps', () => {
 				.reply(200, {
 					name: 'the-app'
 				});
-			const name = await getAppName({ appId });
+			const name = await getAppName(appId);
 			expect(name).toEqual('the-app');
 		});
 
@@ -157,7 +157,7 @@ describe('review-apps', () => {
 				});
 
 			try {
-				await getAppName({ appId });
+				await getAppName(appId);
 			} catch (error) {
 				expect(error.message).toEqual('Some error occurred');
 			}
@@ -251,10 +251,12 @@ describe('review-apps', () => {
 				.reply(200, [ reviewAppBuild ]);
 
 			const waitedReviewAppBuild = await waitForReviewAppBuild({
-				commit
-			})({ reviewAppId, appId });
+				commit,
+				reviewAppId,
+				appId
+			});
 
-			expect(waitedReviewAppBuild).toEqual({ appId });
+			expect(waitedReviewAppBuild).toEqual(appId);
 		});
 
 		it('will delete review app and throw error in event of no review app build for commit', async () => {
@@ -271,8 +273,10 @@ describe('review-apps', () => {
 			try {
 				await waitForReviewAppBuild({
 					commit,
+					reviewAppId,
+					appId,
 					minTimeout: 0
-				})({ reviewAppId, appId });
+				});
 			} catch (error) {
 				const { message } = error;
 				expect(message).toMatch('No review app build found for app id');
@@ -302,10 +306,12 @@ describe('review-apps', () => {
 
 			const waitedReviewAppBuild = await waitForReviewAppBuild({
 				commit,
+				reviewAppId,
+				appId,
 				minTimeout: 0
-			})({ reviewAppId, appId });
+			});
 
-			expect(waitedReviewAppBuild).toEqual({ appId });
+			expect(waitedReviewAppBuild).toEqual(appId);
 		});
 
 		it('waits for succeeded review app build from pending', async () => {
@@ -335,10 +341,12 @@ describe('review-apps', () => {
 
 			const waitedReviewAppBuild = await waitForReviewAppBuild({
 				commit,
+				reviewAppId,
+				appId,
 				minTimeout: 0
-			})({ reviewAppId, appId });
+			});
 
-			expect(waitedReviewAppBuild).toEqual({ appId });
+			expect(waitedReviewAppBuild).toEqual(appId);
 		});
 
 		it('fails for failed review app build with output stream link', async () => {
@@ -359,8 +367,10 @@ describe('review-apps', () => {
 			try {
 				await waitForReviewAppBuild({
 					commit,
+					reviewAppId,
+					appId,
 					minTimeout: 0
-				})({ reviewAppId, appId });
+				});
 			} catch (e) {
 				const { message } = e;
 				expect(message).toMatch('Review app build failed');
@@ -385,8 +395,10 @@ describe('review-apps', () => {
 
 			return waitForReviewAppBuild({
 				commit,
+				reviewAppId,
+				appId,
 				minTimeout: 0
-			})({ reviewAppId, appId })
+			})
 				.catch((error) => {
 					const { message } = error;
 					expect(message).toMatch('Review app build for app id \'app123\' (commit \'a00000000000\') not done yet: pending');
@@ -411,9 +423,9 @@ describe('review-apps', () => {
 					status: 'created'
 				});
 
-			const waitedReviewAppBuild = await waitTillReviewAppCreated()(reviewApp);
+			const waitedReviewAppBuild = await waitTillReviewAppCreated({ reviewApp });
 
-			expect(waitedReviewAppBuild).toEqual({ reviewAppId, appId });
+			expect(waitedReviewAppBuild).toEqual(appId);
 		});
 
 		it('waits for review app id until created', async () => {
@@ -439,10 +451,11 @@ describe('review-apps', () => {
 				});
 
 			const waitedReviewAppBuild = await waitTillReviewAppCreated({
+				reviewApp,
 				minTimeout: 0
-			})(reviewApp);
+			});
 
-			expect(waitedReviewAppBuild).toEqual({ reviewAppId, appId });
+			expect(waitedReviewAppBuild).toEqual(appId);
 		});
 
 		it('waits for review app id even if there is a http error', async () => {
@@ -463,10 +476,11 @@ describe('review-apps', () => {
 				});
 
 			const waitedReviewAppBuild = await waitTillReviewAppCreated({
+				reviewApp,
 				minTimeout: 0
-			})(reviewApp);
+			});
 
-			expect(waitedReviewAppBuild).toEqual({ reviewAppId, appId });
+			expect(waitedReviewAppBuild).toEqual(appId);
 		});
 
 		it('throws error if review app status is deleted', async () => {
@@ -479,7 +493,7 @@ describe('review-apps', () => {
 					status: 'deleted'
 				});
 
-			return waitTillReviewAppCreated()(reviewApp)
+			return waitTillReviewAppCreated({ reviewApp })
 				.catch(error => {
 					const { message } = error;
 					expect(message).toMatch('Review app was deleted');
@@ -496,7 +510,7 @@ describe('review-apps', () => {
 					status: 'errored'
 				});
 
-			return waitTillReviewAppCreated()(reviewApp)
+			return waitTillReviewAppCreated({ reviewApp })
 				.catch(error => {
 					const { message } = error;
 					expect(message).toMatch('Review app errored');
@@ -514,7 +528,7 @@ describe('review-apps', () => {
 					status: 'errored'
 				});
 
-			return waitTillReviewAppCreated()(reviewApp)
+			return waitTillReviewAppCreated({ reviewApp })
 				.catch(error => {
 					const { message } = error;
 					expect(message).toMatch('Review app errored');
@@ -548,7 +562,7 @@ describe('review-apps', () => {
 					}
 				]);
 
-			return waitTillReviewAppCreated({ commit })(reviewApp)
+			return waitTillReviewAppCreated({ reviewApp, commit })
 				.catch(() => {
 					expect(console.error.mock.calls[0][0]).toMatch('https://heroku.com/builds/output/app123'); // eslint-disable-line no-console
 				});
@@ -569,7 +583,7 @@ describe('review-apps', () => {
 			nockScope.get('/apps/app123/builds')
 				.reply(400);
 
-			return waitTillReviewAppCreated()(reviewApp)
+			return waitTillReviewAppCreated({ reviewApp })
 				.catch(() => {
 					expect(console.error.mock.calls[0][0]).toMatch('Could not get app build'); // eslint-disable-line no-console
 				});
@@ -585,7 +599,7 @@ describe('review-apps', () => {
 				.times(60)
 				.reply(200, []);
 
-			return waitTillReviewAppCreated({ minTimeout: 0 })(reviewApp)
+			return waitTillReviewAppCreated({ reviewApp, minTimeout: 0 })
 				.catch((error) => {
 					const { message } = error;
 					expect(message).toMatch('Review app not created yet');


### PR DESCRIPTION
Jira card: [Investigate Heroku review apps issues](https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=1051&modal=detail&selectedIssue=CPP-159).

CircleCI builds are encountering failures that look like this: https://circleci.com/gh/Financial-Times/next-preflight/6729.

```
{ Error: No review app build found for app id '8e6b4116-2f77-438e-a35e-6f0a98b05d46';, commit '75b2f4e0a27ece478170d1d404c0cb347406d0df'
	at getAppBuildWithCommit.then (/home/circleci/project/build/node_modules/@financial-times/n-heroku-tools/lib/review-apps.js:161:12)
	at <anonymous>
	at process._tickDomainCallback (internal/process/next_tick.js:229:7) attemptNumber: 61, retriesLeft: 0 }
```

It usually (quite possibly exclusively) occurs following a rebase with another branch, though engineering a rebase does not always reliably reproduce the issue.

The solution developers have been using to fix this problem is to delete the Heroku review app and re-run the CircleCI workflow, which is a time-wasting process.

This PR implements logic so that in the event of an app ID not having a corresponding build, the review app that is no longer usable is deleted and the process to create a review app starts over.

The `review-apps.js` file (amended in this PR) uses a package called `pRetry`, which allows functions to (as the name suggests) retry a function for a specified number of attempts, with a specified interval between each. A normal error will trigger a retry of the function but an abortive error (`pRetry.AbortError`) will break out of the retry loop.

Such a retry loop has now been applied to the main function in this file (i.e. the one that covers the entire creation process) so that in the event of an absent build a retry can be attempted (post-deletion of the unusable review app).

This has introduced some complexity in that some of the functions this main function calls have their own retry loops, and so the logic depends on the correct type of error thrown in the right place, i.e. `Error` or `pRetry.AbortError`.

I have refactored the functions to use `await` exclusively for handling asynchronous code as there was a mix with `.then` and `.catch`, as well as renaming some of the functions and adding more unit tests.

Naturally, now that I want to test it on production (by pointing an app to this branch of `n-herouk-tools` as its dependency) I cannot reproduce the error, but thought it would be useful to get PR feedback in the meantime while I figure that out.