### PR TITLE
CPP-249 -  unclear errors thrown by `nht configure`

### DIFF
--- a/lib/heroku-api.js
+++ b/lib/heroku-api.js
@@ -22,8 +22,8 @@ function herokuApi ({ endpoint, authToken, options = {} }) {
 			let err = new Error(`BadResponse: ${url} - ${status} ${statusText}`);
 			err.name = 'BAD_RESPONSE';
 			err.status = status;
-			url.search('/config-vars') > 0 && (status === 422 || status ===  400) ? 
-			err.hint = 'Check Vault for invalid variable values (remove empty strings and change numbers to strings).' : '';
+			url.search('/config-vars') > 0 && (status === 422 || status === 400) ?
+				err.hint = 'Check Vault for invalid variable values (remove empty strings and change numbers to strings).' : '';
 			return response.text().then(text => {
 				try {
 					err.responseJson = JSON.parse(text);

--- a/lib/heroku-api.js
+++ b/lib/heroku-api.js
@@ -22,6 +22,8 @@ function herokuApi ({ endpoint, authToken, options = {} }) {
 			let err = new Error(`BadResponse: ${url} - ${status} ${statusText}`);
 			err.name = 'BAD_RESPONSE';
 			err.status = status;
+			url.search('/config-vars') > 0 && (status === 422 || status ===  400) ? 
+			err.hint = 'Check Vault for invalid variable values (remove empty strings and change numbers to strings).' : '';
 			return response.text().then(text => {
 				try {
 					err.responseJson = JSON.parse(text);

--- a/lib/heroku-api.js
+++ b/lib/heroku-api.js
@@ -22,8 +22,9 @@ function herokuApi ({ endpoint, authToken, options = {} }) {
 			let err = new Error(`BadResponse: ${url} - ${status} ${statusText}`);
 			err.name = 'BAD_RESPONSE';
 			err.status = status;
-			url.search('/config-vars') > 0 && (status === 422 || status === 400) ?
-				err.hint = 'Check Vault for invalid variable values (remove empty strings and change numbers to strings).' : '';
+			if (url.search('/config-vars') > 0 && (status === 422 || status === 400)) {
+				err.hint = 'Check Vault for invalid variable values (remove empty strings and change numbers to strings).';
+			}
 			return response.text().then(text => {
 				try {
 					err.responseJson = JSON.parse(text);

--- a/lib/heroku-api.js
+++ b/lib/heroku-api.js
@@ -22,9 +22,6 @@ function herokuApi ({ endpoint, authToken, options = {} }) {
 			let err = new Error(`BadResponse: ${url} - ${status} ${statusText}`);
 			err.name = 'BAD_RESPONSE';
 			err.status = status;
-			if (url.search('/config-vars') > 0 && (status === 422 || status === 400)) {
-				err.hint = 'Check Vault for invalid variable values (remove empty strings and change numbers to strings).';
-			}
 			return response.text().then(text => {
 				try {
 					err.responseJson = JSON.parse(text);

--- a/tasks/configure.js
+++ b/tasks/configure.js
@@ -92,17 +92,12 @@ const getPipelineId = async (pipelineName) => {
 	return pipeline.id;
 };
 
-const validateVariables = (obj) => {
-	// removes empty strings and numbers
-	let filteredObj = {};
+const warnForInvalidVariables = (obj) => {
 	Object.keys(obj).forEach(prop => {
-		if (obj[prop] !== '' && typeof obj[prop] !== 'number') {
-			filteredObj[prop] = obj[prop];
-		} else {
-			console.log(`WARNING - Removing invalid variable '${prop}', variable values cannot be empty strings or numbers.`); // eslint-disable-line no-console
+		if (obj[prop] === '' || typeof obj[prop] === 'number') {
+			console.log(`WARNING - Invalid variable '${prop}'. Variable values cannot be empty strings or numbers, please fix this in the Vault UI.`); // eslint-disable-line no-console
 		}
 	});
-	return filteredObj;
 };
 
 async function task (opts) {
@@ -166,8 +161,8 @@ async function task (opts) {
 	});
 
 	console.log('Setting config vars', Object.keys(patch)); // eslint-disable-line no-console
-
-	await herokuConfigVars.set(validateVariables(patch));
+	warnForInvalidVariables(patch);
+	await herokuConfigVars.set(patch);
 
 	console.log(`${target} config vars are set`); // eslint-disable-line no-console
 };

--- a/tasks/configure.js
+++ b/tasks/configure.js
@@ -97,13 +97,13 @@ const validateVariables = (obj) => {
 	let filteredObj = {};
 	Object.keys(obj).forEach(prop => {
 		if (obj[prop] !== '' && typeof obj[prop] !== 'number') {
-			filteredObj[prop] = obj[prop]
+			filteredObj[prop] = obj[prop];
 		} else {
 			console.log(`WARNING - Removing invalid variable '${prop}', variable values cannot be empty strings or numbers.`); // eslint-disable-line no-console
 		}
-	})
+	});
 	return filteredObj;
-}
+};
 
 async function task (opts) {
 	let source = opts.source || 'ft-next-' + normalizeName(packageJson.name);

--- a/tasks/configure.js
+++ b/tasks/configure.js
@@ -92,14 +92,6 @@ const getPipelineId = async (pipelineName) => {
 	return pipeline.id;
 };
 
-const warnForInvalidVariables = (obj) => {
-	Object.keys(obj).forEach(prop => {
-		if (obj[prop] === '' || typeof obj[prop] === 'number') {
-			console.log(`WARNING - Invalid variable '${prop}'. Variable values cannot be empty strings or numbers, please fix this in the Vault UI.`); // eslint-disable-line no-console
-		}
-	});
-};
-
 async function task (opts) {
 	let source = opts.source || 'ft-next-' + normalizeName(packageJson.name);
 	let target = opts.target || source;
@@ -160,8 +152,13 @@ async function task (opts) {
 		}
 	});
 
+	const invalidVariables = Object.keys(patch).filter(prop => patch[prop] === '' || typeof patch[prop] === 'number');
+	if (invalidVariables.length > 0) {
+		throw new Error(`Variable values cannot be empty strings or numbers, please fix the following variables in the Vault UI: ${invalidVariables.join(', ')}`);
+	}
+
 	console.log('Setting config vars', Object.keys(patch)); // eslint-disable-line no-console
-	warnForInvalidVariables(patch);
+
 	await herokuConfigVars.set(patch);
 
 	console.log(`${target} config vars are set`); // eslint-disable-line no-console

--- a/tasks/configure.js
+++ b/tasks/configure.js
@@ -92,6 +92,19 @@ const getPipelineId = async (pipelineName) => {
 	return pipeline.id;
 };
 
+const validateVariables = (obj) => {
+	// removes empty strings and numbers
+	let filteredObj = {};
+	Object.keys(obj).forEach(prop => {
+		if (obj[prop] !== '' && typeof obj[prop] !== 'number') {
+			filteredObj[prop] = obj[prop]
+		} else {
+			console.log(`WARNING - Removing invalid variable '${prop}', variable values cannot be empty strings or numbers.`); // eslint-disable-line no-console
+		}
+	})
+	return filteredObj;
+}
+
 async function task (opts) {
 	let source = opts.source || 'ft-next-' + normalizeName(packageJson.name);
 	let target = opts.target || source;
@@ -154,7 +167,7 @@ async function task (opts) {
 
 	console.log('Setting config vars', Object.keys(patch)); // eslint-disable-line no-console
 
-	await herokuConfigVars.set(patch);
+	await herokuConfigVars.set(validateVariables(patch));
 
 	console.log(`${target} config vars are set`); // eslint-disable-line no-console
 };


### PR DESCRIPTION
[ticket](https://financialtimes.atlassian.net/browse/CPP-249)

- ~~removes config variables if their values are empty string or number~~
- if a variable is invalid it logs a warning message
- it adds a hint to the error saying to review Vault for invalid variables.