### PR TITLE
CPP-309 changed glob pattern to match subdirectories

### DIFF
--- a/tasks/upload-assets-to-s3.js
+++ b/tasks/upload-assets-to-s3.js
@@ -58,7 +58,7 @@ async function uploadFile (file, opts, s3) {
 }
 
 async function uploadAssetsToS3 (opts) {
-	const files = glob.sync(`${opts.directory}/*{${opts.extensions}}`);
+	const files = glob.sync(`${opts.directory}/**/*{${opts.extensions}}`);
 
 	const s3 = new aws.S3({
 		accessKeyId: opts.accessKeyId,

--- a/tasks/upload-assets-to-s3.js
+++ b/tasks/upload-assets-to-s3.js
@@ -30,7 +30,7 @@ function getFileEncoding (filename) {
 }
 
 async function uploadFile (file, opts, s3) {
-	const basename = path.basename(file);
+	const basename = file.replace(/^.+?[/]/, ''); // remove first directory only
 	const type = getFileType(basename);
 	const encoding = getFileEncoding(basename);
 	const key = path.posix.join(opts.destination, basename);

--- a/tasks/upload-assets-to-s3.js
+++ b/tasks/upload-assets-to-s3.js
@@ -30,7 +30,7 @@ function getFileEncoding (filename) {
 }
 
 async function uploadFile (file, opts, s3) {
-	const basename = file.replace(/^.+?[/]/, ''); // remove first directory only
+	const basename = file.split('/').splice(1).join('/'); // remove first directory only
 	const type = getFileType(basename);
 	const encoding = getFileEncoding(basename);
 	const key = path.posix.join(opts.destination, basename);

--- a/tasks/upload-assets-to-s3.test.js
+++ b/tasks/upload-assets-to-s3.test.js
@@ -8,7 +8,8 @@ const mockGlobSync = jest.fn().mockReturnValue([
 	'public/stylesheet.css.gz',
 	'public/scripts.js',
 	'public/scripts.js.br',
-	'public/scripts.js.gz'
+	'public/scripts.js.gz',
+	'public/subdir/hello.js',
 ]);
 
 jest.mock('aws-sdk', () => {
@@ -115,6 +116,17 @@ describe('upload-assets-to-s3', () => {
 			expect.objectContaining({
 				Key: 'bucket-folder/scripts.js.gz',
 				ContentEncoding: 'gzip'
+			}),
+			expect.any(Function)
+		);
+	});
+
+	it('uploads files in subdirectories', () => {
+		expect(mockS3Upload).nthCalledWith(
+			7,
+			expect.objectContaining({
+				Key: 'bucket-folder/subdir/hello.js',
+				ContentType: 'application/javascript; charset=utf-8'
 			}),
 			expect.any(Function)
 		);


### PR DESCRIPTION
[Ticket CPP-309](https://financialtimes.atlassian.net/browse/CPP-309)

Changed the glob pattern in `uploadAssetsToS3` to be from `<directory>/*{<extensions>}` to `<directory>/**/*{<extensions>}` so that it would match subdirectories

Still need to test alongside the PageKit Images plugin