### PR TITLE
CPP-298 Wait for approval on CircleCI builds from nori and renovate PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,14 @@ references:
     branches:
       ignore: /.*/
 
+filters_only_renovate: &filters_only_renovate
+    branches:
+      only: /^renovate-.*/
+
+filters_only_nori: &filters_only_nori
+    branches:
+      only: /^nori/.*/
+
 version: 2
 
 jobs:
@@ -115,6 +123,32 @@ jobs:
 workflows:
 
   version: 2
+
+  renovate-build-test:
+    jobs:
+      - waiting-for-approval:
+          type: approval
+          filters:
+              <<: *filters_only_renovate
+      - build:
+          requires:
+              - waiting-for-approval
+      - test:
+          requires:
+              - build
+
+  nori-build-test:
+    jobs:
+    - waiting-for-approval:
+        type: approval
+        filters:
+            <<: *filters_only_nori
+    - build:
+        requires:
+            - waiting-for-approval
+    - test:
+        requires:
+            - build
 
   build-test:
     jobs:


### PR DESCRIPTION
Renovate and Nori create many PRs which queue loads of builds in CircleCI blocking other PRs across the entire organisation from building, as a solution we are having PRs created by Renovate and Nori pause from building until approved. <br/><br/>This PR was created using a nori script 🍙<br/><br/>_Nori is a command-line application for managing changes across multiple (usually Github) repositories._