### PR TITLE
CPP-442 Upgrade GitHub repos from `master` to `main #256

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,9 +31,9 @@ references:
     restore_cache:
         <<: *npm_cache_keys
 
-  filters_only_master: &filters_only_master
+  filters_only_main: &filters_only_main
     branches:
-      only: master
+      only: main
 
   filters_ignore_tags: &filters_ignore_tags
     tags:
@@ -165,7 +165,7 @@ workflows:
       - schedule:
           cron: "0 0 * * *"
           filters:
-            <<: *filters_only_master
+            <<: *filters_only_main
     jobs:
       - build:
           context: next-nightly-build

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Commands:
   configure [options] [source] [target]               gets environment variables from Vault and uploads them to the current app
   deploy-static [options] <source> [otherSources...]  Deploys static <source> to S3.  Requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY env vars
   run [options]                                       Runs the local app through the router
-  rebuild [options] [apps...]                         Trigger a rebuild of the latest master on Circle
+  rebuild [options] [apps...]                         DEPRECATED. Trigger a rebuild of the latest master on Circle
   gtg [app]                                           Runs gtg checks for an app
   review-app [options] [appName]                      Create or find an existing heroku review app and print out the app name. [appName] is the package.json name (which is also the value of VAULT_NAME). On the first build of a branch, Heroku will create a review app with a build. On subsequent builds, Heroku will automatically generate a new build, which this task looks for. See https://devcenter.heroku.com/articles/review-apps-beta for more details of the internals
   upload-assets-to-s3 [options]                       Uploads a folder of assets to an S3 bucket

--- a/lib/host.js
+++ b/lib/host.js
@@ -8,12 +8,6 @@ module.exports = {
 				'test';
 	},
 
-	isMasterBranch: () => {
-		return process.env.CIRCLE_BRANCH === 'master' ||
-				process.env.GIT_BRANCH === 'master' ||
-			(!process.env.TRAVIS_PULL_REQUEST && process.env.TRAVIS_BRANCH === 'master');
-	},
-
 	url: (appName) => {
 		let host = appName || 'http://local.ft.com:3002';
 		if (!/:|\./.test(host)) {


### PR DESCRIPTION
Ticket CPP-442 Upgrade GitHub repos from master to main

The changes include updating .circleci/config.yml to filter on main branch instead of master.
Removing unused `isMasterBranch` function, and added DEPRECATED note for nht rebuild.