### PR TITLE
CPP-576 Use renovate-config-next-beta in Platforms Owned repos

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "extends": [
-    "github>financial-times/renovate-config-next"
+    "github>financial-times/renovate-config-next-beta"
   ]
 }


### PR DESCRIPTION
[Ticket CPP-576](https://financialtimes.atlassian.net/browse/CPP-576)<p>The [beta version](https://github.com/Financial-Times/renovate-config-next-beta) is a fork of the renovate-config-next repo, but since that configuration can't be versioned, that repo contains some backwards-incompatible changes that we wanted to introduce.</p><p>_This PR was created by [nori](https://github.com/Financial-Times/nori)_</p>