### PR TITLE
Upgrade to Node 14/16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,11 @@ references:
     &container_config_node
     working_directory: ~/project/build
     docker:
-      - image: cimg/node:12.22
+      - image: cimg/node:<< parameters.node-version >>
+    parameters:
+      node-version:
+        default: "16.14"
+        type: string
 
   workspace_root: &workspace_root ~/project
 
@@ -138,26 +142,46 @@ workflows:
       - build:
           filters:
             <<: *filters_ignore_tags_renovate_nori
+          name: build-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
       - test:
           requires:
-            - build
+            - build-v<< matrix.node-version >>
+          name: test-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
 
   build-test-publish:
     jobs:
       - build:
           filters:
             <<: *filters_version_tag
+          name: build-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
       - test:
           filters:
             <<: *filters_version_tag
           requires:
-            - build
+            - build-v<< matrix.node-version >>
+          name: test-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
       - publish:
           context: npm-publish-token
           filters:
             <<: *filters_version_tag
           requires:
-            - test
+            - test-v<< matrix.node-version >>
+          name: publish-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
 
   renovate-nori-build-test:
     jobs:
@@ -168,9 +192,17 @@ workflows:
       - build:
           requires:
             - waiting-for-approval
+          name: build-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
       - test:
           requires:
-            - build
+            - build-v<< matrix.node-version >>
+          name: test-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
 
   nightly:
     triggers:
@@ -181,10 +213,18 @@ workflows:
     jobs:
       - build:
           context: next-nightly-build
+          name: build-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
       - test:
           requires:
-            - build
+            - build-v<< matrix.node-version >>
           context: next-nightly-build
+          name: test-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
 
 notify:
   webhooks:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@financial-times/n-heroku-tools",
   "version": "0.0.0",
   "engines": {
-    "node": "12.x",
+    "node": "14.x || 16.x",
     "npm": "7.x || 8.x"
   },
   "bin": {
@@ -53,7 +53,7 @@
     }
   },
   "volta": {
-    "node": "12.22.5",
+    "node": "16.14.0",
     "npm": "7.20.2"
   }
 }


### PR DESCRIPTION
Upgrade the repository to a newer version of Node now that Node 12 is approaching end-of-life. If this repository is a Heroku app it will be updated to Node 16, the most recent LTS release; if it is an AWS Lambda it will be updated to Node 14, the latest version supported by AWS; and if it is a library or tool it will be updated to suppport either Node 14 or Node 16 so that it can be used by either Heroku or Lambda apps. This is an automated [Nori](https://github.com/Financial-Times/nori) operation so this message can't specify which type your library is, sorry!