### PR TITLE
Uppercase all HTTP verbs for native Fetch support

### DIFF
--- a/lib/heroku-config-vars.js
+++ b/lib/heroku-config-vars.js
@@ -49,7 +49,7 @@ class HerokuConfigVars {
 	*/
 	set (patch) {
 		return this.makeApiCall({
-			method: 'patch',
+			method: 'PATCH',
 			body: JSON.stringify(patch)
 		});
 	}

--- a/lib/review-apps.js
+++ b/lib/review-apps.js
@@ -125,7 +125,7 @@ const deleteReviewAppAndThrowError = async ({ reviewApp, commit, appId }) => {
 
 		const headers = await herokuHeaders({ useReviewAppApi: true });
 
-		await performFetch(getReviewAppUrl(reviewApp.id), { headers, method: 'delete' });
+		await performFetch(getReviewAppUrl(reviewApp.id), { headers, method: 'DELETE' });
 
 	} catch (error) {
 
@@ -261,7 +261,7 @@ const createReviewApp = async ({ pipelineId, repoName, commit, branch, githubTok
 		}
 	};
 
-	const response = await fetch(REVIEW_APPS_URL, { headers, method: 'post', body: JSON.stringify(body) });
+	const response = await fetch(REVIEW_APPS_URL, { headers, method: 'POST', body: JSON.stringify(body) });
 
 	return response;
 


### PR DESCRIPTION
### The problem
Standard Fetch spec will only automatically uppercase RFC9110-compliant http verbs - see [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/fetch). This implies that custom methods like `PATCH` will be broken if they are passed to the Fetch API as lowercase.

This becomes an issue for n-gage heroku projects migrating to Node 18 which include a native global `fetch` and replaces `isomorphic-fetch` polyfill. CI workflows to deploy  review apps will fail as seen [here](https://app.circleci.com/pipelines/github/Financial-Times/next-consent-proxy/2210/workflows/52544f57-a8ad-4824-8d23-d9f0138a2d81) because the HTTP verb `patch` is invalid for configuring the Heroku pipeline

### Notes
See this [Slack conversation](https://financialtimes.slack.com/archives/C3TJ6KXEU/p1679317662364499) for context

### Solution
This commit ONLY sets a precedent/convention for using uppercase methods in the project as there's no centralized callsite for `fetch` in the project and no easy way to override the behavior for native fetch. Also, projects are expected to migrate away from `n-heroku-tools` in the nearest future